### PR TITLE
fix!: ConvertToDateTime crops precision to ms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- ConvertToDateTime() crops fraction of second to milliseconds instead of full seconds
+
+### Added
+
+- ConvertToDateTimeMS is new function
+
 ## [0.6.1] - 2023-03-07
 
 ### Changed
@@ -32,6 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Tests with well-known MPDs
 - Tweaked XML library to support namespaces
 
+[Unreleased]: https://github.com/Eyevinn/dash-mpd/compare/v0.6.1...HEAD
 [0.6.1]: https://github.com/Eyevinn/dash-mpd/compare/v0.6.0...v0.6.1
 [0.6.0]: https://github.com/Eyevinn/dash-mpd/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/Eyevinn/dash-mpd/releases/tag/v0.5.0

--- a/mpd/io.go
+++ b/mpd/io.go
@@ -41,16 +41,27 @@ func (m *MPD) Write(w io.Writer) (int, error) {
 	return w.Write(data)
 }
 
-// ConvertToDateTime converts a number of seconds to a UTC DateTime.
+const RFC3339MS string = "2006-01-02T15:04:05.999Z07:00"
+
+// ConvertToDateTime converts a number of seconds to a UTC DateTime by cropping to ms precision.
 func ConvertToDateTime(seconds float64) DateTime {
 	s := int64(seconds)
 	ns := int64((seconds - float64(s)) * 1_000_000_000)
 	t := time.Unix(s, ns).UTC()
-	return DateTime(t.Format(time.RFC3339Nano))
+
+	return DateTime(t.Format(RFC3339MS))
 }
 
-// ConvertToDateTime converts an intergral number of seconds to a UTC DateTime.
+// ConvertToDateTime converts an integral number of seconds to a UTC DateTime.
 func ConvertToDateTimeS(seconds int64) DateTime {
 	t := time.Unix(seconds, 0).UTC()
-	return DateTime(t.Format(time.RFC3339Nano))
+	return DateTime(t.Format(RFC3339MS))
+}
+
+// ConvertToDateTime converts an integral number of milliseconds to a UTC DateTime.
+func ConvertToDateTimeMS(ms int64) DateTime {
+	seconds := ms / 1000
+	ns := (ms - 1000*seconds) * 1_000_000
+	t := time.Unix(seconds, ns).UTC()
+	return DateTime(t.Format(RFC3339MS))
 }

--- a/mpd/io_test.go
+++ b/mpd/io_test.go
@@ -14,6 +14,8 @@ func TestDateTime(t *testing.T) {
 	}{
 		{0, "1970-01-01T00:00:00Z"},
 		{0.5, "1970-01-01T00:00:00.5Z"},
+		{0.333, "1970-01-01T00:00:00.333Z"},
+		{0.666, "1970-01-01T00:00:00.666Z"},
 		{946684800, "2000-01-01T00:00:00Z"},
 	}
 	for _, tc := range cases {
@@ -32,6 +34,20 @@ func TestDateTimeS(t *testing.T) {
 	}
 	for _, tc := range cases {
 		got := mpd.ConvertToDateTimeS(tc.inTimeS)
+		require.Equal(t, tc.dateTime, got)
+	}
+}
+
+func TestDateTimeMS(t *testing.T) {
+	cases := []struct {
+		inTimeMS int64
+		dateTime mpd.DateTime
+	}{
+		{0, "1970-01-01T00:00:00Z"},
+		{946684800120, "2000-01-01T00:00:00.12Z"},
+	}
+	for _, tc := range cases {
+		got := mpd.ConvertToDateTimeMS(tc.inTimeMS)
 		require.Equal(t, tc.dateTime, got)
 	}
 }

--- a/mpd/mpd.go
+++ b/mpd/mpd.go
@@ -519,12 +519,13 @@ type SegmentTemplateType struct {
 }
 
 // S is the S element of SegmentTimeline. All time units in media timescale.
+// Defined in ISO/IEC 23009-1 Section 5.3.9.6
 type S struct {
-	// T is start time of first Segment in the the series relative to presentation time offset.
+	// T is presentation time of first Segment in sequence relative to presentationTimeOffset.
 	T *uint64 `xml:"t,attr"`
-	// N is the Segment number of the first Segment in the series.
+	// N is is first Segment number in Segment sequence relative startNumber
 	N *uint64 `xml:"n,attr"`
-	// D is the Segment duration or the duration of a Segment sequence.
+	// D is the Segment duration.
 	D uint64 `xml:"d,attr"`
 	// R is repeat count (how many times to repeat. -1 is unlimited)
 	R int `xml:"r,attr,omitempty"` // default = 0


### PR DESCRIPTION
Before, the output of DateTime was always full seconds. This is too limiting for publishTime with short segments or non-integral availabilityTimeOffset. Therefore, the accuracy has been increased to milliseconds.

New function ConvertToDateTimeMS