### PR TITLE
Fix infinite availabilityTimeOffset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - ConvertToDateTime() crops fraction of second to milliseconds instead of full seconds
 
+### Fixed
+
+- Infinite value of availabilityTimeOffset is now marshalled/unmarshalled as "INF"
+
 ### Added
 
 - ConvertToDateTimeMS is new function

--- a/mpd/mpd_test.go
+++ b/mpd/mpd_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestDecodeEncodeMPDs(t *testing.T) {
-	testDirs := []string{"testdata/go-dash-fixtures", "testdata/schema-mpds"}
+	testDirs := []string{"testdata/go-dash-fixtures", "testdata/schema-mpds", "testdata/livesim"}
 	for _, testDir := range testDirs {
 		fsys := os.DirFS(testDir)
 		mpdFiles, err := fs.Glob(fsys, "*.mpd")

--- a/mpd/testdata/livesim/ato-inf.mpd
+++ b/mpd/testdata/livesim/ato-inf.mpd
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<MPD xmlns="urn:mpeg:dash:schema:mpd:2011" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" availabilityStartTime="1970-01-01T00:00:00Z"
+id="1" maxSegmentDuration="PT2S" minBufferTime="PT2S" minimumUpdatePeriod="PT10M"
+profiles="urn:mpeg:dash:profile:isoff-live:2011,http://dashif.org/guidelines/dash-if-simple"
+publishTime="1970-01-01T00:00:00Z" timeShiftBufferDepth="PT5M" type="dynamic" xsi:schemaLocation="urn:mpeg:dash:schema:mpd:2011 DASH-MPD.xsd">
+   <ProgramInformation>
+      <Title>Media Presentation Description from DASH-IF live simulator</Title>
+   </ProgramInformation>
+   <BaseURL availabilityTimeOffset="INF">https://livesim.dashif.org/livesim/sts_1679588477/sid_9c8db005/ato_inf/testpic_2s/</BaseURL>
+<Period id="p0" start="PT0S">
+      <AdaptationSet contentType="audio" lang="en" mimeType="audio/mp4" segmentAlignment="true" startWithSAP="1">
+         <Role schemeIdUri="urn:mpeg:dash:role:2011" value="main" />
+         <SegmentTemplate duration="2" initialization="$RepresentationID$/init.mp4" media="$RepresentationID$/$Number$.m4s" startNumber="0" />
+         <Representation audioSamplingRate="48000" bandwidth="48000" codecs="mp4a.40.2" id="A48">
+            <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2" />
+         </Representation>
+      </AdaptationSet>
+      <AdaptationSet contentType="video" maxFrameRate="60/2" maxHeight="360" maxWidth="640" mimeType="video/mp4" minHeight="360" minWidth="640" par="16:9" segmentAlignment="true" startWithSAP="1">
+         <Role schemeIdUri="urn:mpeg:dash:role:2011" value="main" />
+         <SegmentTemplate duration="2" initialization="$RepresentationID$/init.mp4" media="$RepresentationID$/$Number$.m4s" startNumber="0" />
+         <Representation bandwidth="300000" codecs="avc1.64001e" frameRate="60/2" height="360" id="V300" sar="1:1" width="640" />
+      </AdaptationSet>
+   </Period>
+</MPD>


### PR DESCRIPTION
A typical use case for the MPD is to have an infinite availabilityTimeOffset.
That is also used as a test case in dash.js.

The xml library marshals float64 infinity to "Inf", but the XML representation should be "INF".
A new type and custom Marshal/Unmarshal methods have been added to accomplish this.