### PR TITLE
feat: lots of convenience functions for generating MPDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Nothing yet
+### Changed
+
+- `NewMPD` function now also sets DASH namespace
+- `mpd.Write` now has two parameters to set indentation and an optional XML header
+- renamed constants StaticMpdType and DynamicMpdType to `STATIC_TYPE` and `DYNAMIC_TYPE`
+
+### Added
+
+Lots of convenience functions to create MPDs
+
+- `mpd.WriteToString` function to return a string
+- constants for many common values like audio-channel-configuration
+- `rep.SetSegmentBase` method
+- `NewBaseURL` function for simple BaseURL cases
+- `NewDescriptor` function for creating a DescriptorType instance
+- `NewRole` function for creating a new DescriptorType for a role
+- `listOfTypes.AddProfile` method to add a profile
+- `NewAdaptationSetWithParams` function for generating AdaptationSet
+- `NewRepresentationWithID` function for generating a representation with a few parameters
+- `NewAudioRepresentation` function for audio representations
+- `NewVideoRepresentation` function for video representation
+- `Seconds2DurPtrFloat64` to generate a pointer to duration specified as seconds using float64
 
 ## [0.9.1] - 2023-05-17
 

--- a/examples/newmpd_test.go
+++ b/examples/newmpd_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func ExampleNewMPD() {
-	m := mpd.NewMPD(mpd.StaticMPDType)
+	m := mpd.NewMPD(mpd.STATIC_TYPE)
 	m.Profiles = "urn:mpeg:dash:profile:isoff-live:2011,http://dashif.org/guidelines/dash-if-simple"
 	p := mpd.NewPeriod()
 	m.AppendPeriod(p)
@@ -33,7 +33,7 @@ func ExampleNewMPD() {
 	out, _ := xml.MarshalIndent(m, " ", "")
 
 	fmt.Println(string(out))
-	// Output: <MPD profiles="urn:mpeg:dash:profile:isoff-live:2011,http://dashif.org/guidelines/dash-if-simple" type="static">
+	// Output: <MPD xmlns="urn:mpeg:dash:schema:mpd:2011" profiles="urn:mpeg:dash:profile:isoff-live:2011,http://dashif.org/guidelines/dash-if-simple" type="static">
 	//  <Period id="p0">
 	//  <AdaptationSet lang="en" contentType="audio">
 	//  <SegmentTemplate media="$RepresentationID$/$Number$.m4s" initialization="$RepresentationID$/init.mp4" duration="2" startNumber="1"></SegmentTemplate>

--- a/mpd/io.go
+++ b/mpd/io.go
@@ -39,13 +39,35 @@ func MPDFromBytes(data []byte) (*MPD, error) {
 	return &mpd, nil
 }
 
-// Write marshals and writes an MPD.
-func (m *MPD) Write(w io.Writer) (int, error) {
-	data, err := xml.MarshalIndent(m, "", "  ")
+// Write writes to w, with indentation according to indent and optionally adding an XML header.
+func (m *MPD) Write(w io.Writer, indent string, withHeader bool) (n int, err error) {
+	data, err := xml.MarshalIndent(m, "", indent)
 	if err != nil {
 		return 0, err
 	}
-	return w.Write(data)
+	nTot := 0
+	if withHeader {
+		n, err = w.Write([]byte(xml.Header))
+		if err != nil {
+			return n, err
+		}
+		nTot += n
+	}
+	n, err = w.Write(data)
+	nTot += n
+	return nTot, err
+}
+
+// WriteToString returns a string, with indentation according to indent and optionally adding an XML header.
+func (m *MPD) WriteToString(indent string, withHeader bool) (string, error) {
+	data, err := xml.MarshalIndent(m, "", indent)
+	if err != nil {
+		return "", err
+	}
+	if withHeader {
+		return xml.Header + string(data), nil
+	}
+	return string(data), nil
 }
 
 const RFC3339MS string = "2006-01-02T15:04:05.999Z07:00"

--- a/mpd/mpd_test.go
+++ b/mpd/mpd_test.go
@@ -92,7 +92,7 @@ func BenchmarkClone(b *testing.B) {
 
 func TestNewFunction(t *testing.T) {
 
-	_, err := xml.Marshal(m.NewMPD(m.DynamicMPDType))
+	_, err := xml.Marshal(m.NewMPD(m.DYNAMIC_TYPE))
 	require.NoError(t, err)
 
 	_, err = xml.Marshal(m.NewPeriod())

--- a/mpd/period.go
+++ b/mpd/period.go
@@ -123,7 +123,7 @@ func (p *Period) GetStart() (Duration, error) {
 		return 0, ErrUnknownPeriodStart
 	}
 	// first period of static, but no start => start = 0
-	if m.GetType() == StaticMPDType {
+	if m.GetType() == STATIC_TYPE {
 		return 0, nil
 	}
 	return 0, ErrUnknownPeriodStart
@@ -144,7 +144,7 @@ func (p *Period) GetDuration() (Duration, error) {
 		return 0, err
 	}
 	switch m.GetType() {
-	case StaticMPDType:
+	case STATIC_TYPE:
 		if m.MediaPresentationDuration == nil {
 			return 0, ErrNoMediaPresentationDuration
 		}

--- a/mpd/period_test.go
+++ b/mpd/period_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestAbsolutePeriodStart(t *testing.T) {
-	m := mpd.NewMPD(mpd.DynamicMPDType)
+	m := mpd.NewMPD(mpd.DYNAMIC_TYPE)
 	m.AvailabilityStartTime = mpd.DateTime("1970-01-01T00:00:00Z")
 	for i := 0; i < 3; i++ {
 		p := mpd.NewPeriod()
@@ -52,14 +52,14 @@ func TestPeriodStart(t *testing.T) {
 	}{
 		{
 			desc:         "dynamic, single-period",
-			mpdType:      mpd.DynamicMPDType,
+			mpdType:      mpd.DYNAMIC_TYPE,
 			mupPresent:   true,
 			data:         []mpdData{{mpd.Seconds2DurPtr(12), nil}},
 			wantedStarts: []mpd.Duration{mpd.Duration(12 * time.Second)},
 		},
 		{
 			desc:       "dynamic, single-period",
-			mpdType:    mpd.DynamicMPDType,
+			mpdType:    mpd.DYNAMIC_TYPE,
 			mupPresent: true,
 			data: []mpdData{
 				{mpd.Seconds2DurPtr(12), mpd.Seconds2DurPtr(60)},
@@ -72,7 +72,7 @@ func TestPeriodStart(t *testing.T) {
 		},
 		{
 			desc:       "static, single-period without start",
-			mpdType:    mpd.StaticMPDType,
+			mpdType:    mpd.STATIC_TYPE,
 			mupPresent: false,
 			data: []mpdData{
 				{nil, nil},
@@ -109,20 +109,20 @@ type mpdData struct {
 }
 
 func TestMpdStartErrors(t *testing.T) {
-	m := mpd.NewMPD(mpd.DynamicMPDType)
+	m := mpd.NewMPD(mpd.DYNAMIC_TYPE)
 	p := mpd.NewPeriod()
 	m.Periods = append(m.Periods, p)
 	_, err := p.GetStart()
 	require.EqualError(t, err, mpd.ErrParentNotSet.Error())
 
-	m = mpd.NewMPD(mpd.DynamicMPDType)
+	m = mpd.NewMPD(mpd.DYNAMIC_TYPE)
 	p = mpd.NewPeriod()
 	m.AppendPeriod(p)
 	m.Periods = nil
 	_, err = p.GetStart()
 	require.EqualError(t, err, mpd.ErrPeriodNotFound.Error())
 
-	m = mpd.NewMPD(mpd.DynamicMPDType)
+	m = mpd.NewMPD(mpd.DYNAMIC_TYPE)
 	p = mpd.NewPeriod()
 	m.AppendPeriod(p)
 	p = mpd.NewPeriod()
@@ -130,7 +130,7 @@ func TestMpdStartErrors(t *testing.T) {
 	_, err = p.GetStart()
 	require.EqualError(t, err, mpd.ErrUnknownPeriodStart.Error())
 
-	m = mpd.NewMPD(mpd.DynamicMPDType)
+	m = mpd.NewMPD(mpd.DYNAMIC_TYPE)
 	p = mpd.NewPeriod()
 	p.Duration = mpd.Seconds2DurPtr(30)
 	m.AppendPeriod(p)
@@ -151,21 +151,21 @@ func TestPeriodType(t *testing.T) {
 	}{
 		{
 			desc:        "dynamic, single-period",
-			mpdType:     mpd.DynamicMPDType,
+			mpdType:     mpd.DYNAMIC_TYPE,
 			mupPresent:  false,
 			data:        []mpdData{{mpd.Seconds2DurPtr(0), nil}},
 			wantedTypes: []mpd.PeriodType{mpd.PTRegular},
 		},
 		{
 			desc:        "static, single-period",
-			mpdType:     mpd.StaticMPDType,
+			mpdType:     mpd.STATIC_TYPE,
 			mupPresent:  false,
 			data:        []mpdData{{mpd.Seconds2DurPtr(0), nil}},
 			wantedTypes: []mpd.PeriodType{mpd.PTRegular},
 		},
 		{
 			desc:       "dynamic, first with dur, next without start and dur",
-			mpdType:    mpd.DynamicMPDType,
+			mpdType:    mpd.DYNAMIC_TYPE,
 			mupPresent: true,
 			data: []mpdData{
 				{mpd.Seconds2DurPtr(0), mpd.Seconds2DurPtr(20)},
@@ -175,7 +175,7 @@ func TestPeriodType(t *testing.T) {
 		},
 		{
 			desc:       "dynamic, first with dur, next without start and dur",
-			mpdType:    mpd.DynamicMPDType,
+			mpdType:    mpd.DYNAMIC_TYPE,
 			mupPresent: true,
 			data: []mpdData{
 				{mpd.Seconds2DurPtr(0), mpd.Seconds2DurPtr(20)},
@@ -185,7 +185,7 @@ func TestPeriodType(t *testing.T) {
 		},
 		{
 			desc:       "dynamic, early available first segment",
-			mpdType:    mpd.DynamicMPDType,
+			mpdType:    mpd.DYNAMIC_TYPE,
 			mupPresent: true,
 			data: []mpdData{
 				{nil, nil},
@@ -194,7 +194,7 @@ func TestPeriodType(t *testing.T) {
 		},
 		{
 			desc:       "dynamic, early available second segment",
-			mpdType:    mpd.DynamicMPDType,
+			mpdType:    mpd.DYNAMIC_TYPE,
 			mupPresent: true,
 			data: []mpdData{
 				{mpd.Seconds2DurPtr(0), nil},
@@ -226,13 +226,13 @@ func TestPeriodType(t *testing.T) {
 }
 
 func TestMpdTypeErrors(t *testing.T) {
-	m := mpd.NewMPD(mpd.DynamicMPDType)
+	m := mpd.NewMPD(mpd.DYNAMIC_TYPE)
 	p := mpd.NewPeriod()
 	m.Periods = append(m.Periods, p)
 	_, err := p.GetType()
 	require.EqualError(t, err, mpd.ErrParentNotSet.Error())
 
-	m = mpd.NewMPD(mpd.DynamicMPDType)
+	m = mpd.NewMPD(mpd.DYNAMIC_TYPE)
 	p = mpd.NewPeriod()
 	m.AppendPeriod(p)
 	m.Periods = nil
@@ -252,7 +252,7 @@ func TestGetDuration(t *testing.T) {
 	}{
 		{
 			desc:         "static with duration",
-			mpdType:      mpd.StaticMPDType,
+			mpdType:      mpd.STATIC_TYPE,
 			mediaPresDur: 0,
 			data:         []mpdData{{nil, mpd.Seconds2DurPtr(60)}},
 			wantedDurs:   []mpd.Duration{mpd.Duration(60 * time.Second)},
@@ -260,7 +260,7 @@ func TestGetDuration(t *testing.T) {
 		},
 		{
 			desc:         "static without mediaPresendationDuration",
-			mpdType:      mpd.StaticMPDType,
+			mpdType:      mpd.STATIC_TYPE,
 			mediaPresDur: 0,
 			data:         []mpdData{{mpd.Seconds2DurPtr(0), nil}},
 			wantedDurs:   nil,
@@ -268,7 +268,7 @@ func TestGetDuration(t *testing.T) {
 		},
 		{
 			desc:         "static not-last without next start",
-			mpdType:      mpd.StaticMPDType,
+			mpdType:      mpd.STATIC_TYPE,
 			mediaPresDur: 120,
 			data: []mpdData{
 				{mpd.Seconds2DurPtr(0), nil},
@@ -282,7 +282,7 @@ func TestGetDuration(t *testing.T) {
 		},
 		{
 			desc:         "static with next start",
-			mpdType:      mpd.StaticMPDType,
+			mpdType:      mpd.STATIC_TYPE,
 			mediaPresDur: 120,
 			data: []mpdData{
 				{mpd.Seconds2DurPtr(0), nil},
@@ -296,7 +296,7 @@ func TestGetDuration(t *testing.T) {
 		},
 		{
 			desc:         "dynamic, no start",
-			mpdType:      mpd.DynamicMPDType,
+			mpdType:      mpd.DYNAMIC_TYPE,
 			mediaPresDur: 0,
 			data:         []mpdData{{nil, nil}},
 			wantedDurs:   nil,
@@ -304,7 +304,7 @@ func TestGetDuration(t *testing.T) {
 		},
 		{
 			desc:         "dynamic, single-period",
-			mpdType:      mpd.DynamicMPDType,
+			mpdType:      mpd.DYNAMIC_TYPE,
 			mediaPresDur: 0,
 			data:         []mpdData{{mpd.Seconds2DurPtr(0), nil}},
 			wantedDurs:   nil,
@@ -312,7 +312,7 @@ func TestGetDuration(t *testing.T) {
 		},
 		{
 			desc:         "dynamic, without next start",
-			mpdType:      mpd.DynamicMPDType,
+			mpdType:      mpd.DYNAMIC_TYPE,
 			mediaPresDur: 0,
 			data: []mpdData{
 				{mpd.Seconds2DurPtr(0), nil},
@@ -326,7 +326,7 @@ func TestGetDuration(t *testing.T) {
 		},
 		{
 			desc:         "dynamic with next start",
-			mpdType:      mpd.DynamicMPDType,
+			mpdType:      mpd.DYNAMIC_TYPE,
 			mediaPresDur: 0,
 			data: []mpdData{
 				{mpd.Seconds2DurPtr(0), nil},

--- a/mpd/ptrs.go
+++ b/mpd/ptrs.go
@@ -1,6 +1,9 @@
 package mpd
 
-import "time"
+import (
+	"math"
+	"time"
+)
 
 // Ptr returns a pointer to any value
 func Ptr[T any](v T) *T {
@@ -10,5 +13,12 @@ func Ptr[T any](v T) *T {
 // Seconds2DurPtr returns a pointer to a duration given a time in seconds
 func Seconds2DurPtr(seconds int) *Duration {
 	d := Duration(time.Duration(seconds) * time.Second)
+	return &d
+}
+
+// Seconds2DurPtrFloat64 returns a pointer to a duration given a float64 time in seconds.
+func Seconds2DurPtrFloat64(seconds float64) *Duration {
+	us := time.Duration(math.Round(seconds * 1_000_000))
+	d := Duration(us * time.Microsecond)
 	return &d
 }

--- a/mpd/ptrs_test.go
+++ b/mpd/ptrs_test.go
@@ -1,0 +1,32 @@
+package mpd_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/Eyevinn/dash-mpd/mpd"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSeconds2DurPtr(t *testing.T) {
+	cases := []struct {
+		seconds   float64
+		wantedDur mpd.Duration
+	}{
+		{
+			seconds: 0, wantedDur: 0,
+		},
+		{
+			seconds: 0.5, wantedDur: mpd.Duration(500 * time.Millisecond),
+		},
+		{
+			seconds: 1.3, wantedDur: mpd.Duration(1300 * time.Millisecond),
+		},
+	}
+
+	for _, c := range cases {
+		p := mpd.Seconds2DurPtrFloat64(c.seconds)
+		require.Equal(t, c.wantedDur, *p)
+	}
+
+}


### PR DESCRIPTION
### Changed

- `NewMPD` function now also sets DASH namespace
- `mpd.Write` now has two parameters to set indentation and an optional XML header
- renamed constants StaticMpdType and DynamicMpdType to `STATIC_TYPE` and `DYNAMIC_TYPE`

### Added

Lots of convenience functions to create MPDs

- `mpd.WriteToString` function to return a string
- constants for many common values like audio-channel-configuration
- `rep.SetSegmentBase` method
- `NewBaseURL` function for simple BaseURL cases
- `NewDescriptor` function for creating a DescriptorType instance
- `NewRole` function for creating a new DescriptorType for a role
- `listOfTypes.AddProfile` method to add a profile
- `NewAdaptationSetWithParams` function for generating AdaptationSet
- `NewRepresentationWithID` function for generating a representation with a few parameters
- `NewAudioRepresentation` function for audio representations
- `NewVideoRepresentation` function for video representation
- `Seconds2DurPtrFloat64` to generate a pointer to duration specified as seconds using float64
