### PR TITLE
Support for Marlin and DASH-IF ClearKey content protection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - GetContentProtections, GetMimeType, GetCodecs, and GetSegmentTemplate methods for AdaptationSet and Representation
 - ContentProtection elements and name spaces for Marlin DRM and DASH-IF ClearKey
 
+### Fixed
+
+- ContentProtection and other parts of RepresentationBaseType moved before other elements in AdaptationSet and Representation
+
 ## [0.10.0] - 2023-05-26
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - GetContentProtections, GetMimeType, GetCodecs, and GetSegmentTemplate methods for AdaptationSet and Representation
+- ContentProtection elements and name spaces for Marlin DRM and DASH-IF ClearKey
 
 ## [0.10.0] - 2023-05-26
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ needed. The main modifications made were:
   value `false` or be absent
 * Add type comments and document enum values for certain types
 * Change names to plural for all subelement slices, e.g. Periods instead of Period
-* Add `cenc:pssh` and `mspr:pro` DRM elements
+* Add ContentProtection elements and corresponding name spaces
 
 ## XML handling
 
@@ -74,13 +74,16 @@ and how the output looks:
    comes from the XML schema. The order is therefore often different from the input document.
 4. Mapping to float numbers may not preserve the exact value of the input.
 5. Addition of extra name spaces, such as specific DRM systems must be done explicitly.
-6. Durations are mapped to nanoseconds and back. This may change the duration slightly. All trailing zeros
+6. In the output, the name-spaces are added to the level where they are used and not at the top MPD level.
+   The output names are also fixed, and may differ from the input names.
+7. Durations are mapped to nanoseconds and back. This may change the duration slightly. All trailing zeros
    are also removed, as are the minutes and seconds counts if they are zero and a bigger unit is present.
 
 ## Tests
 
-The MPD marshaling/unmarshaling is tested by by using many MPDs in the `testdata/schema-mpds` and
-`testdata/go-dash-fixtures` directories. See the README.md files in these directorie for their
+The MPD marshaling/unmarshaling is tested by by using many MPDs in the `testdata/schema-mpds`,
+`testdata/go-dash-fixtures`, and `testdata/livesim` directories.
+See the README.md files in these directories for their
 origins and the small tweaks needed to make durations and some other values consistent after a
 unmarshaling/marshaling process.
 

--- a/go.mod
+++ b/go.mod
@@ -5,16 +5,16 @@ go 1.19
 require (
 	aqwari.net/xml v0.0.0-20210331023308-d9421b293817
 	github.com/barkimedes/go-deepcopy v0.0.0-20220514131651-17c30cfc62df
-	github.com/google/go-cmp v0.5.9
-	github.com/stretchr/testify v1.8.2
+	github.com/google/go-cmp v0.6.0
+	github.com/stretchr/testify v1.8.4
 )
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/kr/pretty v0.2.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	golang.org/x/net v0.8.0 // indirect
-	golang.org/x/text v0.8.0 // indirect
+	golang.org/x/net v0.19.0 // indirect
+	golang.org/x/text v0.14.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -7,6 +7,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
+github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/kr/pretty v0.2.0 h1:s5hAObm+yFO5uHYt5dYjxi2rXrsnmRpJx4OYvIWUaQs=
 github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
@@ -21,6 +23,8 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
 github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
+github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
@@ -32,6 +36,8 @@ golang.org/x/net v0.0.0-20200625001655-4c5254603344/go.mod h1:/O7V0waA8r7cgGh81R
 golang.org/x/net v0.0.0-20200813134508-3edf25e44fcc/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.8.0 h1:Zrh2ngAOFYneWTAIAPethzeaQLuHwhuBkuV6ZiRnUaQ=
 golang.org/x/net v0.8.0/go.mod h1:QVkue5JL9kW//ek3r6jTKnTFis1tRmNAW2P1shuFdJc=
+golang.org/x/net v0.19.0 h1:zTwKpTd2XuCqf8huc7Fo2iSy+4RHPd10s4KzeTnVr1c=
+golang.org/x/net v0.19.0/go.mod h1:CfAk/cbD4CthTvqiEl8NpboMuiuOYsAr/7NOjZJtv1U=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -40,6 +46,8 @@ golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.8.0 h1:57P1ETyNKtuIjB4SRd15iJxuhj8Gc416Y78H3qgMh68=
 golang.org/x/text v0.8.0/go.mod h1:e1OnstbJyHTd6l/uOt8jFFHp6TRDWZR/bV3emEE/zU8=
+golang.org/x/text v0.14.0 h1:ScX5w1eTa3QqT8oi6+ziP7dTV1S2+ALU0bI+0zXKWiQ=
+golang.org/x/text v0.14.0/go.mod h1:18ZOQIKpY8NJVqYksKHtTdi31H5itFRjB5/qKTNYzSU=
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20200821192610-3366bbee4705/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/mpd/mpd.go
+++ b/mpd/mpd.go
@@ -27,6 +27,13 @@ const (
 	MIME_TYPE_TTML                         = "application/ttml+xml"
 )
 
+const (
+	DRM_CLEAR_KEY_DASHIF = "urn:uuid:e2719d58-a985-b3c9-781a-b030af78d30e"
+	DRM_PLAYREADY        = "urn:uuid:9a04f079-9840-4286-ab92-e65be0885f95"
+	DRM_WIDEVINE         = "urn:uuid:edef8ba9-79d6-4ace-a3c8-27dcd51d21ed"
+	DRM_MARLIN           = "urn:uuid:5e629af5-38dA-4063-8977-97ffbd9902d4"
+)
+
 // MPD is MPEG-DASH Media Presentation Description (MPD) as defined in ISO/IEC 23009-1 5'th edition.
 //
 // The tree of structs is generated from the corresponding XML Schema at https://github.com/MPEGGroup/DASHSchema
@@ -510,6 +517,12 @@ type ContentProtectionType struct {
 	Pssh *PsshType `xml:"urn:mpeg:cenc:2013 cenc:pssh,omitempty"`
 	// MSPro is Microsoft PlayReady provisioning data with namespace "urn:microsoft:playready and "prefix "mspr".
 	MSPro *MSProType `xml:"urn:microsoft:playready mspr:pro,omitempty"`
+	// ClearKey is DASH-IF clear key
+	ClearKey *ClearKeyType `xml:"http://dashif.org/guidelines/clearKey ck:Laurl,omitempty"`
+	// LaURL is DASH-IF License Acquisition URL.
+	LaURL *LaURL `xml:"https://dashif.org/ dashif:laurl,omitempty"`
+	// MarlinContentIds is Marlin Content Ids containing one or more MarlineContentId elements.
+	MarlinContentIds *MarlinContentIds `xml:"urn:marlin:mas:1-0:services:schemas:mpd mas:MarlinContentIds,omitempty"`
 	DescriptorType
 }
 
@@ -520,6 +533,27 @@ type PsshType struct {
 
 // MSProType is Microsoft PlayReady provisioning data.
 type MSProType struct {
+	Value string `xml:",chardata"`
+}
+
+// ClearKeyType is DASH-IF clear key type
+type ClearKeyType struct {
+	LicType string `xml:"Lic_type,attr"`
+	Value   string `xml:",chardata"`
+}
+
+// LaURL is License Acquisition URL.
+type LaURL struct {
+	Value string `xml:",chardata"`
+}
+
+// MarlinContentIds is Marlin Content Ids containing one or more MarlineContentId elements.
+type MarlinContentIds struct {
+	Cids []*MarlinContentId `xml:"urn:marlin:mas:1-0:services:schemas:mpd mas:MarlinContentId"`
+}
+
+// MarlinContentId is Marlin Content Id.
+type MarlinContentId struct {
 	Value string `xml:",chardata"`
 }
 

--- a/mpd/mpd.go
+++ b/mpd/mpd.go
@@ -241,41 +241,41 @@ type UIntVWithIDType struct {
 // AdaptationSetType is AdaptationSet or EmptyAdaptationSet.
 // Note that XMLName is not set, since the same structure is used also for EmptyAdaptationSet.
 type AdaptationSetType struct {
-	XlinkHref               string                  `xml:"xlink:href,attr,omitempty"`
-	XlinkActuate            string                  `xml:"xlink:actuate,attr,omitempty"` // default is "onRequest"
-	XlinkType               string                  `xml:"xlink:type,attr,omitempty"`    // fixed "simple"
-	XlinkShow               string                  `xml:"xlink:show,attr,omitempty"`    // fixed "embed"
-	Id                      *uint32                 `xml:"id,attr"`
-	Group                   uint32                  `xml:"group,attr,omitempty"`
-	Lang                    string                  `xml:"lang,attr,omitempty"`
-	ContentType             RFC6838ContentTypeType  `xml:"contentType,attr,omitempty"`
-	Par                     RatioType               `xml:"par,attr,omitempty"`
-	MinBandwidth            uint32                  `xml:"minBandwidth,attr,omitempty"`
-	MaxBandwidth            uint32                  `xml:"maxBandwidth,attr,omitempty"`
-	MinWidth                uint32                  `xml:"minWidth,attr,omitempty"`
-	MaxWidth                uint32                  `xml:"maxWidth,attr,omitempty"`
-	MinHeight               uint32                  `xml:"minHeight,attr,omitempty"`
-	MaxHeight               uint32                  `xml:"maxHeight,attr,omitempty"`
-	MinFrameRate            string                  `xml:"minFrameRate,attr,omitempty"`
-	MaxFrameRate            string                  `xml:"maxFrameRate,attr,omitempty"`
-	SegmentAlignment        bool                    `xml:"segmentAlignment,attr,omitempty"`        // default = false
-	SubsegmentAlignment     bool                    `xml:"subsegmentAlignment,attr,omitempty"`     // default = false
-	SubsegmentStartsWithSAP uint32                  `xml:"subsegmentStartsWithSAP,attr,omitempty"` // default = 0
-	BitstreamSwitching      *bool                   `xml:"bitstreamSwitching,attr"`
-	InitializationSetRef    *UIntVectorType         `xml:"initializationSetRef,attr,omitempty"`
-	InitializationPrincipal AnyURI                  `xml:"initializationPrincipal,attr,omitempty"`
-	Accessibilities         []*DescriptorType       `xml:"Accessibility"`
-	Roles                   []*DescriptorType       `xml:"Role"`
-	Ratings                 []*DescriptorType       `xml:"Rating"`
-	Viewpoints              []*DescriptorType       `xml:"Viewpoint"`
-	ContentComponents       []*ContentComponentType `xml:"ContentComponent"`
-	BaseURLs                []*BaseURLType          `xml:"BaseURL"`
-	SegmentBase             *SegmentBaseType        `xml:"SegmentBase"`
-	SegmentList             *SegmentListType        `xml:"SegmentList"`
-	SegmentTemplate         *SegmentTemplateType    `xml:"SegmentTemplate"`
-	Representations         []*RepresentationType   `xml:"Representation"`
-	parent                  *Period                 `xml:"-"`
+	XlinkHref               string                 `xml:"xlink:href,attr,omitempty"`
+	XlinkActuate            string                 `xml:"xlink:actuate,attr,omitempty"` // default is "onRequest"
+	XlinkType               string                 `xml:"xlink:type,attr,omitempty"`    // fixed "simple"
+	XlinkShow               string                 `xml:"xlink:show,attr,omitempty"`    // fixed "embed"
+	Id                      *uint32                `xml:"id,attr"`
+	Group                   uint32                 `xml:"group,attr,omitempty"`
+	Lang                    string                 `xml:"lang,attr,omitempty"`
+	ContentType             RFC6838ContentTypeType `xml:"contentType,attr,omitempty"`
+	Par                     RatioType              `xml:"par,attr,omitempty"`
+	MinBandwidth            uint32                 `xml:"minBandwidth,attr,omitempty"`
+	MaxBandwidth            uint32                 `xml:"maxBandwidth,attr,omitempty"`
+	MinWidth                uint32                 `xml:"minWidth,attr,omitempty"`
+	MaxWidth                uint32                 `xml:"maxWidth,attr,omitempty"`
+	MinHeight               uint32                 `xml:"minHeight,attr,omitempty"`
+	MaxHeight               uint32                 `xml:"maxHeight,attr,omitempty"`
+	MinFrameRate            string                 `xml:"minFrameRate,attr,omitempty"`
+	MaxFrameRate            string                 `xml:"maxFrameRate,attr,omitempty"`
+	SegmentAlignment        bool                   `xml:"segmentAlignment,attr,omitempty"`        // default = false
+	SubsegmentAlignment     bool                   `xml:"subsegmentAlignment,attr,omitempty"`     // default = false
+	SubsegmentStartsWithSAP uint32                 `xml:"subsegmentStartsWithSAP,attr,omitempty"` // default = 0
+	BitstreamSwitching      *bool                  `xml:"bitstreamSwitching,attr"`
+	InitializationSetRef    *UIntVectorType        `xml:"initializationSetRef,attr,omitempty"`
+	InitializationPrincipal AnyURI                 `xml:"initializationPrincipal,attr,omitempty"`
 	RepresentationBaseType
+	Accessibilities   []*DescriptorType       `xml:"Accessibility"`
+	Roles             []*DescriptorType       `xml:"Role"`
+	Ratings           []*DescriptorType       `xml:"Rating"`
+	Viewpoints        []*DescriptorType       `xml:"Viewpoint"`
+	ContentComponents []*ContentComponentType `xml:"ContentComponent"`
+	BaseURLs          []*BaseURLType          `xml:"BaseURL"`
+	SegmentBase       *SegmentBaseType        `xml:"SegmentBase"`
+	SegmentList       *SegmentListType        `xml:"SegmentList"`
+	SegmentTemplate   *SegmentTemplateType    `xml:"SegmentTemplate"`
+	Representations   []*RepresentationType   `xml:"Representation"`
+	parent            *Period                 `xml:"-"`
 }
 
 func (a *AdaptationSetType) SetParent(p *Period) {
@@ -329,22 +329,23 @@ type ContentComponentType struct {
 
 // RepresentationType is Representation.
 type RepresentationType struct {
-	XMLName                xml.Name                 `xml:"Representation"`
-	Id                     string                   `xml:"id,attr"`
-	Bandwidth              uint32                   `xml:"bandwidth,attr"`
-	QualityRanking         *uint32                  `xml:"qualityRanking,attr,omitempty"`
-	DependencyId           *StringVectorType        `xml:"dependencyId,attr,omitempty"`
-	AssociationId          *StringVectorType        `xml:"associationId,attr,omitempty"`
-	AssociationType        *ListOf4CCType           `xml:"associationType,attr,omitempty"`
-	MediaStreamStructureId *StringVectorType        `xml:"mediaStreamStructureId,attr,omitempty"`
-	BaseURLs               []*BaseURLType           `xml:"BaseURL"`
-	ExtendedBandwidths     []*ExtendedBandwidthType `xml:"ExtendedBandwidth"`
-	SubRepresentations     []*SubRepresentationType `xml:"SubRepresentation"`
-	SegmentBase            *SegmentBaseType         `xml:"SegmentBase"`
-	SegmentList            *SegmentListType         `xml:"SegmentList"`
-	SegmentTemplate        *SegmentTemplateType     `xml:"SegmentTemplate"`
-	parent                 *AdaptationSetType       `xml:"-"` // adaptation set
+	XMLName                xml.Name          `xml:"Representation"`
+	Id                     string            `xml:"id,attr"`
+	Bandwidth              uint32            `xml:"bandwidth,attr"`
+	QualityRanking         *uint32           `xml:"qualityRanking,attr,omitempty"`
+	DependencyId           *StringVectorType `xml:"dependencyId,attr,omitempty"`
+	AssociationId          *StringVectorType `xml:"associationId,attr,omitempty"`
+	AssociationType        *ListOf4CCType    `xml:"associationType,attr,omitempty"`
+	MediaStreamStructureId *StringVectorType `xml:"mediaStreamStructureId,attr,omitempty"`
 	RepresentationBaseType
+	BaseURLs           []*BaseURLType           `xml:"BaseURL"`
+	ExtendedBandwidths []*ExtendedBandwidthType `xml:"ExtendedBandwidth"`
+	SubRepresentations []*SubRepresentationType `xml:"SubRepresentation"`
+	SegmentBase        *SegmentBaseType         `xml:"SegmentBase"`
+	SegmentList        *SegmentListType         `xml:"SegmentList"`
+	SegmentTemplate    *SegmentTemplateType     `xml:"SegmentTemplate"`
+	parent             *AdaptationSetType       `xml:"-"` // adaptation set
+
 }
 
 func (r *RepresentationType) SetParent(p *AdaptationSetType) {
@@ -386,13 +387,13 @@ type ModelPairType struct {
 
 // SubRepresentationType is SubRepresentation
 type SubRepresentationType struct {
-	XMLName          xml.Name            `xml:"SubRepresentation"`
-	Level            *uint32             `xml:"level,attr,omitempty"`
-	DependencyLevel  *UIntVectorType     `xml:"dependencyLevel,attr,omitempty"`
-	Bandwidth        uint32              `xml:"bandwidth,attr,omitempty"`
-	ContentComponent *StringVectorType   `xml:"contentComponent,attr,omitempty"`
-	parent           *RepresentationType `xml:"-"`
+	XMLName          xml.Name          `xml:"SubRepresentation"`
+	Level            *uint32           `xml:"level,attr,omitempty"`
+	DependencyLevel  *UIntVectorType   `xml:"dependencyLevel,attr,omitempty"`
+	Bandwidth        uint32            `xml:"bandwidth,attr,omitempty"`
+	ContentComponent *StringVectorType `xml:"contentComponent,attr,omitempty"`
 	RepresentationBaseType
+	parent *RepresentationType `xml:"-"`
 }
 
 func (s *SubRepresentationType) SetParent(p *RepresentationType) {

--- a/mpd/mpd_test.go
+++ b/mpd/mpd_test.go
@@ -15,6 +15,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const (
+	printProcessMPDFile = "" // Used to see the output of the process even if there is no essential diff
+)
+
 func TestDecodeEncodeMPDs(t *testing.T) {
 	testDirs := []string{"testdata/go-dash-fixtures", "testdata/schema-mpds", "testdata/livesim"}
 	for _, testDir := range testDirs {
@@ -36,6 +40,10 @@ func TestDecodeEncodeMPDs(t *testing.T) {
 			inTree, err := xmltree.Parse(td)
 			require.NoError(t, err)
 			outTree, err := xmltree.Parse(out)
+			if fName == printProcessMPDFile {
+				err := os.WriteFile(fName, out, 0644)
+				require.NoError(t, err)
+			}
 			require.NoError(t, err)
 			if !xmltree.Equal(inTree, outTree) {
 				inBuf := bytes.Buffer{}
@@ -47,11 +55,9 @@ func TestDecodeEncodeMPDs(t *testing.T) {
 				d := cmp.Diff(inBuf.String(), outBuf.String())
 				// Note. There is no canonicalization and there may
 				// be comments in the input, so the diff is not minimal.
-				t.Errorf("non-minimal diff for mpd %s:\n%s\n", fName, d[:400])
-				ofh, err := os.Create(fName)
+				t.Errorf("non-minimal diff for mpd %s:\n%s. Writing file %s\n", fName, d[:400], fName)
+				err = os.WriteFile(fName, out, 0644)
 				require.NoError(t, err)
-				_, _ = ofh.Write(out)
-				ofh.Close()
 			}
 		}
 	}

--- a/mpd/testdata/livesim/Manifest_thumbs.mpd
+++ b/mpd/testdata/livesim/Manifest_thumbs.mpd
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<MPD xmlns="urn:mpeg:dash:schema:mpd:2011" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+availabilityStartTime="1970-01-01T00:00:00Z" id="Config part of url maybe?" maxSegmentDuration="PT2S"
+minBufferTime="PT2S" minimumUpdatePeriod="PT5M" profiles="urn:mpeg:dash:profile:isoff-live:2011,urn:com:dashif:dash264"
+publishTime="1970-01-01T00:00:00Z" timeShiftBufferDepth="PT5M"
+type="dynamic" xsi:schemaLocation="urn:mpeg:dash:schema:mpd:2011 DASH-MPD.xsd">
+   <ProgramInformation>
+      <Title>DASH-IF thumbnails manifest.</Title>
+   </ProgramInformation>
+   <BaseURL>https://livesim.dashif.org/livesim/sts_1679656686/sid_fc1c5dae/testpic_2s/</BaseURL>
+<Period id="p0" start="PT0S">
+      <AdaptationSet contentType="audio" lang="en" mimeType="audio/mp4" segmentAlignment="true" startWithSAP="1">
+         <Role schemeIdUri="urn:mpeg:dash:role:2011" value="main" />
+         <SegmentTemplate duration="2" initialization="$RepresentationID$/init.mp4" media="$RepresentationID$/$Number$.m4s" startNumber="0" />
+         <Representation audioSamplingRate="48000" bandwidth="48000" codecs="mp4a.40.2" id="A48">
+            <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2" />
+         </Representation>
+      </AdaptationSet>
+      <AdaptationSet contentType="video" maxFrameRate="60/2" maxHeight="360" maxWidth="640" mimeType="video/mp4" minHeight="360" minWidth="640" par="16:9" segmentAlignment="true" startWithSAP="1">
+         <Role schemeIdUri="urn:mpeg:dash:role:2011" value="main" />
+         <SegmentTemplate duration="2" initialization="$RepresentationID$/init.mp4" media="$RepresentationID$/$Number$.m4s" startNumber="0" />
+         <Representation bandwidth="300000" codecs="avc1.64001e" frameRate="60/2" height="360" id="V300" sar="1:1" width="640" />
+      </AdaptationSet>
+      <AdaptationSet contentType="image" mimeType="image/jpeg">
+         <SegmentTemplate duration="2" media="$RepresentationID$/$Number$.jpg" startNumber="0" />
+         <Representation bandwidth="10000" height="90" id="thumbs" width="160">
+           <EssentialProperty schemeIdUri="http://dashif.org/guidelines/thumbnail_tile" value="1x1" />
+         </Representation>
+      </AdaptationSet>
+   </Period>
+</MPD>

--- a/mpd/testdata/livesim/README.md
+++ b/mpd/testdata/livesim/README.md
@@ -1,0 +1,7 @@
+# livesim test MPDs
+
+This directory contains extra MPDs for testing that all relevant elements are kept when parsing and writing the MPD.
+
+* ato-inf.mpd contains an infinite availabilityTimeOffset
+* multi-drm.mpd contains DASH-IF clear-key, Marlin, SmoothStreaming and Widevine content protection and corresponding namespaces
+* Manifest_thumbs.mpd contains one DASH-IF thumbnail adaptation set

--- a/mpd/testdata/livesim/multi-drm.mpd
+++ b/mpd/testdata/livesim/multi-drm.mpd
@@ -1,0 +1,30 @@
+<?xml version="1.0" ?>
+<MPD xmlns:cenc="urn:mpeg:cenc:2013" xmlns:ck="http://dashif.org/guidelines/clearKey" xmlns:dashif="https://dashif.org/" xmlns:mas="urn:marlin:mas:1-0:services:schemas:mpd" xmlns:mspr="urn:microsoft:playready" xmlns="urn:mpeg:dash:schema:mpd:2011" profiles="urn:mpeg:dash:profile:isoff-live:2011" minBufferTime="PT1.92S" mediaPresentationDuration="PT5S" type="static">
+  <Period>
+    <AdaptationSet mimeType="video/mp4" segmentAlignment="true" startWithSAP="1" maxWidth="640" maxHeight="360">
+      <ContentProtection schemeIdUri="urn:mpeg:dash:mp4protection:2011" value="cenc" cenc:default_KID="121a0fca-0f1b-475b-8910-297fa8e0a07e"/>
+      <!-- Clear Key -->
+      <ContentProtection schemeIdUri="urn:uuid:e2719d58-a985-b3c9-781a-b030af78d30e" value="ClearKey1.0">
+        <ck:Laurl Lic_type="EME-1.0">http://clearkey.source.org</ck:Laurl>
+        <dashif:laurl>http://clearkey.source.org</dashif:laurl>
+      </ContentProtection>
+      <!-- Marlin -->
+      <ContentProtection schemeIdUri="urn:uuid:5E629AF5-38DA-4063-8977-97FFBD9902D4">
+        <mas:MarlinContentIds>
+          <mas:MarlinContentId>urn:marlin:kid:121a0fca0f1b475b8910297fa8e0a07e</mas:MarlinContentId>
+        </mas:MarlinContentIds>
+      </ContentProtection>
+      <!-- PlayReady -->
+      <ContentProtection schemeIdUri="urn:uuid:9a04f079-9840-4286-ab92-e65be0885f95" value="2.0">
+        <mspr:pro>mgIAAAEAAQCQAjwAVwBSAE0ASABFAEEARABFAFIAIAB4AG0AbABuAHMAPQAiAGgAdAB0AHAAOgAvAC8AcwBjAGgAZQBtAGEAcwAuAG0AaQBjAHIAbwBzAG8AZgB0AC4AYwBvAG0ALwBEAFIATQAvADIAMAAwADcALwAwADMALwBQAGwAYQB5AFIAZQBhAGQAeQBIAGUAYQBkAGUAcgAiACAAdgBlAHIAcwBpAG8AbgA9ACIANAAuADAALgAwAC4AMAAiAD4APABEAEEAVABBAD4APABQAFIATwBUAEUAQwBUAEkATgBGAE8APgA8AEsARQBZAEwARQBOAD4AMQA2ADwALwBLAEUAWQBMAEUATgA+ADwAQQBMAEcASQBEAD4AQQBFAFMAQwBUAFIAPAAvAEEATABHAEkARAA+ADwALwBQAFIATwBUAEUAQwBUAEkATgBGAE8APgA8AEsASQBEAD4AeQBnADgAYQBFAGgAcwBQAFcAMABlAEoARQBDAGwALwBxAE8AQwBnAGYAZwA9AD0APAAvAEsASQBEAD4APABDAEgARQBDAEsAUwBVAE0APgBIAHQAMwB1AGEAeABYADgAMwA5AHMAPQA8AC8AQwBIAEUAQwBLAFMAVQBNAD4APABMAEEAXwBVAFIATAA+AGgAdAB0AHAAOgAvAC8AcABsAGEAeQByAGUAYQBkAHkALgBkAGkAcgBlAGMAdAB0AGEAcABzAC4AbgBlAHQALwBwAHIALwBzAHYAYwAvAHIAaQBnAGgAdABzAG0AYQBuAGEAZwBlAHIALgBhAHMAbQB4ADwALwBMAEEAXwBVAFIATAA+ADwALwBEAEEAVABBAD4APAAvAFcAUgBNAEgARQBBAEQARQBSAD4A</mspr:pro>
+        <cenc:pssh>AAACunBzc2gAAAAAmgTweZhAQoarkuZb4IhflQAAApqaAgAAAQABAJACPABXAFIATQBIAEUAQQBEAEUAUgAgAHgAbQBsAG4AcwA9ACIAaAB0AHQAcAA6AC8ALwBzAGMAaABlAG0AYQBzAC4AbQBpAGMAcgBvAHMAbwBmAHQALgBjAG8AbQAvAEQAUgBNAC8AMgAwADAANwAvADAAMwAvAFAAbABhAHkAUgBlAGEAZAB5AEgAZQBhAGQAZQByACIAIAB2AGUAcgBzAGkAbwBuAD0AIgA0AC4AMAAuADAALgAwACIAPgA8AEQAQQBUAEEAPgA8AFAAUgBPAFQARQBDAFQASQBOAEYATwA+ADwASwBFAFkATABFAE4APgAxADYAPAAvAEsARQBZAEwARQBOAD4APABBAEwARwBJAEQAPgBBAEUAUwBDAFQAUgA8AC8AQQBMAEcASQBEAD4APAAvAFAAUgBPAFQARQBDAFQASQBOAEYATwA+ADwASwBJAEQAPgB5AGcAOABhAEUAaABzAFAAVwAwAGUASgBFAEMAbAAvAHEATwBDAGcAZgBnAD0APQA8AC8ASwBJAEQAPgA8AEMASABFAEMASwBTAFUATQA+AEgAdAAzAHUAYQB4AFgAOAAzADkAcwA9ADwALwBDAEgARQBDAEsAUwBVAE0APgA8AEwAQQBfAFUAUgBMAD4AaAB0AHQAcAA6AC8ALwBwAGwAYQB5AHIAZQBhAGQAeQAuAGQAaQByAGUAYwB0AHQAYQBwAHMALgBuAGUAdAAvAHAAcgAvAHMAdgBjAC8AcgBpAGcAaAB0AHMAbQBhAG4AYQBnAGUAcgAuAGEAcwBtAHgAPAAvAEwAQQBfAFUAUgBMAD4APAAvAEQAQQBUAEEAPgA8AC8AVwBSAE0ASABFAEEARABFAFIAPgA=</cenc:pssh>
+      </ContentProtection>
+      <!-- Widevine -->
+      <ContentProtection schemeIdUri="urn:uuid:edef8ba9-79d6-4ace-a3c8-27dcd51d21ed">
+        <cenc:pssh>AAAATHBzc2gAAAAA7e+LqXnWSs6jyCfc1R0h7QAAACwSEBIaD8oPG0dbiRApf6jgoH4aDXdpZGV2aW5lX3Rlc3QiASoIAUjj3JWbBg==</cenc:pssh>
+      </ContentProtection>
+      <SegmentTemplate timescale="1000" duration="1920" initialization="$RepresentationID$/init.mp4" media="$RepresentationID$/seg-$Number$.m4s" startNumber="1"/>
+      <Representation id="video/avc1" codecs="avc1.64001E" width="640" height="360" scanType="progressive" frameRate="25" bandwidth="741161"/>
+    </AdaptationSet>
+  </Period>
+</MPD>


### PR DESCRIPTION
Now supports Marlin and DASH-IF elements in ContentProtection elements.
The namespaces are added to the top level where they are used in the output.
A new test vector `multi-drm.mpd` has been added

```xml
<ContentProtection schemeIdUri="urn:uuid:e2719d58-a985-b3c9-781a-b030af78d30e" value="ClearKey1.0">
  <ck:Laurl xmlns:ck="http://dashif.org/guidelines/clearKey" Lic_type="EME-1.0">http://clearkey.source.org</ck:Laurl>
  <dashif:laurl xmlns:dashif="https://dashif.org/">http://clearkey.source.org</dashif:laurl>
</ContentProtection>
<ContentProtection schemeIdUri="urn:uuid:5E629AF5-38DA-4063-8977-97FFBD9902D4">
  <mas:MarlinContentIds xmlns:mas="urn:marlin:mas:1-0:services:schemas:mpd">
    <mas:MarlinContentId>urn:marlin:kid:121a0fca0f1b475b8910297fa8e0a07e</mas:MarlinContentId>
  </mas:MarlinContentIds>
</ContentProtection>
```

Should solve #21.