### PR TITLE
Add 5thEdition elements and test data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Updated the G16 example
+- Avoid escaping XML tab and newline in text to align with DASHSchema test content
 
 ### Chore
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Ed5Amd1 element `<SelectionInfo>` inside mixed XML type `<Event>`
+
 ### Fixed
 
 - Updated the G16 example
 - Avoid escaping XML tab and newline in text to align with DASHSchema test content
+- Handle text inside `<Event>`element
 
 ### Chore
 

--- a/mpd/mpd.go
+++ b/mpd/mpd.go
@@ -143,7 +143,8 @@ type EventStreamType struct {
 	Events                 []*EventType `xml:"Event"`
 }
 
-// EventType is Event.
+// EventType is Event. This has settings mixed="true" in the schema, so it can either
+// have charData or child elements or both.
 type EventType struct {
 	XMLName          xml.Name            `xml:"Event"`
 	PresentationTime uint64              `xml:"presentationTime,attr,omitempty"` // default is 0
@@ -151,6 +152,22 @@ type EventType struct {
 	Id               uint32              `xml:"id,attr"`
 	ContentEncoding  ContentEncodingType `xml:"contentEncoding,attr,omitempty"`
 	MessageData      string              `xml:"messageData,attr,omitempty"`
+	Value            string              `xml:",chardata"`
+	SelectionInfo    *SelectionInfoType  `xml:"SelectionInfo"`
+}
+
+// SelectionInfoType is SelectionInfo
+type SelectionInfoType struct {
+	SelectionInfo string           `xml:"selectionInfo,attr,omitempty"`
+	ContactURL    string           `xml:"contactURL,attr"`
+	Selection     []*SelectionType `xml:"Selection"`
+}
+
+// SelectionType is Selection
+type SelectionType struct {
+	DataEncoding string `xml:"dataEncoding,attr,omitempty"`
+	Parameter    string `xml:"parameter,attr"`
+	Data         string `xml:"data,attr,omitempty"`
 }
 
 // InitializationSetType is Initialization Set.

--- a/mpd/testdata/schema-mpds/example_G23.mpd
+++ b/mpd/testdata/schema-mpds/example_G23.mpd
@@ -1,0 +1,27 @@
+<MPD
+    xmlns="urn:mpeg:dash:schema:mpd:2011"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="urn:mpeg:dash:schema:mpd:2011 DASH-MPD.xsd"
+    availabilityStartTime="1970-01-01T00:00:00Z" maxSegmentDuration="PT6S"
+    minBufferTime="PT2S" minimumUpdatePeriod="PT5M"
+    profiles="urn:mpeg:dash:profile:isoff-live:2011" publishTime="2019-03-12T01:17:30Z"
+    timeShiftBufferDepth="PT8M20S" type="dynamic">
+    <Period id="p0" start="PT0S">
+        <BaseURL>http://liveserver.com/live/live1/</BaseURL>
+        <EventStream schemeIdUri="urn:mpeg:dash:event:insertion:2022"
+            value="replace" timescale="1000">
+            <Event duration="60000" id="0">
+				http://acmeadsertver.com/preroll.mpd
+			</Event>
+        </EventStream>
+        <AdaptationSet contentType="video" maxHeight="1920" maxWidth="1080"
+            mimeType="video/mp4" par="16:9" segmentAlignment="true" startWithSAP="1">
+            <SegmentTemplate duration="2" initialization="$RepresentationID$/init.mp4"
+                media="$RepresentationID$/$Number$.m4s" startNumber="0" />
+            <Representation id="V300" bandwidth="300000" codecs="avc1.64001e"
+                frameRate="60/2" />
+            <Representation id="V600" bandwidth="600000" codecs="avc1.64001e"
+                frameRate="60/2" />
+        </AdaptationSet>
+    </Period>
+</MPD>

--- a/mpd/testdata/schema-mpds/example_G24.mpd
+++ b/mpd/testdata/schema-mpds/example_G24.mpd
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<MPD
+    xmlns="urn:mpeg:dash:schema:mpd:2011"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="urn:mpeg:dash:schema:mpd:2011 DASH-MPD.xsd"
+    availabilityStartTime="1970-01-01T00:00:00Z" maxSegmentDuration="PT6S"
+    minBufferTime="PT2S" minimumUpdatePeriod="PT5M"
+    profiles="urn:mpeg:dash:profile:isoff-live:2011" publishTime="2019-03-12T01:17:30Z"
+    timeShiftBufferDepth="PT8M20S" type="dynamic">
+    <Period id="p0" start="PT0S">
+        <BaseURL>http://liveserver.com/live/live1/</BaseURL>
+        <EventStream schemeIdUri="urn:mpeg:dash:event:insertion:2022"
+            value="replace" timescale="1000">
+            <Event presentationTime="60000" duration="10000000" id="0">
+                http://acmeadsertver.com/preroll.mpd
+            </Event>
+        </EventStream>
+        <AdaptationSet contentType="video" maxHeight="1920" maxWidth="1080"
+            mimeType="video/mp4" par="16:9" segmentAlignment="true" startWithSAP="1">
+            <SegmentTemplate duration="2" initialization="$RepresentationID$/init.mp4"
+                media="$RepresentationID$/$Number$.m4s" startNumber="0" />
+            <Representation id="V300" bandwidth="300000" codecs="avc1.64001e"
+                frameRate="60/2" />
+            <Representation id="V600" bandwidth="600000" codecs="avc1.64001e"
+                frameRate="60/2" />
+        </AdaptationSet>
+  </Period>
+</MPD>

--- a/mpd/testdata/schema-mpds/example_G25.mpd
+++ b/mpd/testdata/schema-mpds/example_G25.mpd
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<MPD
+    xmlns="urn:mpeg:dash:schema:mpd:2011"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="urn:mpeg:dash:schema:mpd:2011 DASH-MPD.xsd"
+    availabilityStartTime="1970-01-01T00:00:00Z" maxSegmentDuration="PT6S"
+    minBufferTime="PT2S" minimumUpdatePeriod="PT5M"
+    profiles="urn:mpeg:dash:profile:isoff-live:2011" publishTime="2019-03-12T01:17:30Z"
+    timeShiftBufferDepth="PT8M20S" type="dynamic">
+    <Period id="p0" start="PT0S">
+        <BaseURL>http://liveserver.com/live/live1/</BaseURL>
+        <EventStream schemeIdUri="urn:mpeg:dash:event:insertion:2022"
+            value="insert" timescale="1000">
+            <Event  presentationTime="60000" id="0"
+                duration="120000">http://acmeadsertver.com/preroll.mpd</Event>
+        </EventStream>
+        <AdaptationSet contentType="video" maxHeight="1920" maxWidth="1080"
+            mimeType="video/mp4" par="16:9" segmentAlignment="true" startWithSAP="1">
+            <SegmentTemplate duration="2" initialization="$RepresentationID$/init.mp4"
+                media="$RepresentationID$/$Number$.m4s" startNumber="0" />
+            <Representation id="V300" bandwidth="300000" codecs="avc1.64001e"
+                frameRate="60/2" />
+            <Representation id="V600" bandwidth="600000" codecs="avc1.64001e"
+                frameRate="60/2" />
+        </AdaptationSet>
+    </Period>
+</MPD>
+

--- a/mpd/testdata/schema-mpds/example_G26.mpd
+++ b/mpd/testdata/schema-mpds/example_G26.mpd
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<MPD
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns="urn:mpeg:dash:schema:mpd:2011"
+	xsi:schemaLocation="urn:mpeg:dash:schema:mpd:2011 DASH-MPD.xsd"
+    type="dynamic"
+    minBufferTime="PT2S"
+    profiles="urn:mpeg:dash:profile:isoff-live:2011">
+    <BaseURL>http://cdn1.example.com/</BaseURL>
+    <BaseURL>http://cdn2.example.com/</BaseURL>
+    <Period>
+    	<EventStream schemeIdUri="urn:mpeg:dash:nonlinearplayback:2020"
+        	value="urn:xapp:2020:userinterface1">
+            <Event presentationTime="30" duration="30" id="0">
+				<SelectionInfo
+					selectionInfo="What do you like to happen next?"
+					contactURL="http://cdn.com/content_xyz/">
+					<Selection parameter="1" data="Bill kills Alice"/>
+					<Selection parameter="2" data="Bill kisses Alice"/>
+					<Selection parameter="3" data="Bill frames Alice"/>
+					<Selection parameter="blue" data="Bill kisses Alice"/>
+					<Selection parameter="red" data="Bill frames Alice"/>
+					<Selection parameter="default"/>
+				</SelectionInfo>
+            </Event>
+       </EventStream>
+       <!-- Audio -->
+       <AdaptationSet mimeType="audio/mp4" codecs="mp4a.40" lang="en" subsegmentAlignment="true" subsegmentStartsWithSAP="1">
+            <Representation id="1" bandwidth="64000">
+                <BaseURL>7657412348.mp4</BaseURL>
+            </Representation>
+        </AdaptationSet>
+        <!-- Video -->
+        <AdaptationSet mimeType="video/mp4" codecs="avc1.4d0228" subsegmentAlignment="true" subsegmentStartsWithSAP="2">
+            <Representation id="1" bandwidth="1024000" width="640" height="480">
+                <BaseURL>562465736.mp4</BaseURL>
+            </Representation>
+            <Representation id="2" bandwidth="1384000" width="640" height="480">
+                <BaseURL>41325645.mp4</BaseURL>
+            </Representation>
+            <Representation id="3" bandwidth="1536000" width="1280" height="720">
+                <BaseURL>89045625.mp4</BaseURL>
+            </Representation>
+            <Representation id="4" bandwidth="2048000" width="1280" height="720">
+                <BaseURL>23536745734.mp4</BaseURL>
+            </Representation>
+        </AdaptationSet>
+    </Period>
+</MPD>

--- a/mpd/testdata/schema-mpds/example_G27.mpd
+++ b/mpd/testdata/schema-mpds/example_G27.mpd
@@ -1,0 +1,348 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<MPD xmlns="urn:mpeg:dash:schema:mpd:2011"
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation="urn:mpeg:dash:schema:mpd:2011 DASH-MPD.xsd"
+     xmlns:cenc="urn:mpeg:cenc:2013"
+     type="dynamic"
+     id="42"
+     profiles="urn:mpeg:dash:profile:isoff-live:2011"
+     minBufferTime="PT2S"
+     maxSegmentDuration="PT2.016S"
+     minimumUpdatePeriod="PT2S"
+     availabilityStartTime="1977-05-25T18:00:00.000Z"
+     timeShiftBufferDepth="PT30S"
+     publishTime="2021-04-17T04:15:27.145Z">
+	<Period id="807136760"
+	        start="PT384015H43M16.234S">
+		<!-- SD Adaptation Set (keyID: ed1f2e89-8a1f-47f8-a5f5-371dd397464c) -->
+		<AdaptationSet id="10"
+		               contentType="video"
+		               mimeType="video/mp4"
+		               segmentAlignment="true"
+		               startWithSAP="1">
+			<ContentProtection schemeIdUri="urn:mpeg:dash:mp4protection:2011"
+			                   value="cenc"
+			                   cenc:default_KID="ed1f2e89-8a1f-47f8-a5f5-371dd397464"/>
+			<ContentProtection schemeIdUri="urn:uuid:afbcb50e-bf74-3d13-be8f-13930c783962"
+			                   robustness="SW_SECURE_DECODE">
+				<cenc:pssh>...</cenc:pssh>
+			</ContentProtection>
+			<ContentProtection schemeIdUri="urn:uuid:9a04f079-9840-4286-ab92-e65be0885f95"
+			                   value="MSPR 2.0"
+			                   robustness="SL2000">
+				<cenc:pssh>...</cenc:pssh>
+			</ContentProtection>
+			<!-- Can switch to HD or UHD -->
+			<SupplementalProperty schemeIdUri="urn:mpeg:dash:adaptation-set-switching:2016"
+			                      value="11,12"/>
+			<Accessibility schemeIdUri="urn:scte:dash:cc:cea-608:2015"
+			               value="CC1=eng"/>
+			<Role schemeIdUri="urn:mpeg:dash:role:2011"
+			      value="main"/>
+			<SegmentTemplate initialization="$RepresentationID$/init.mp4"
+			                 media="$RepresentationID$/$Time$.mp4"
+			                 timescale="90000"
+			                 startNumber="807170070"
+			                 presentationTimeOffset="36403">
+				<SegmentTimeline>
+					<S t="6002913283"
+					   d="180180"
+					   r="13"/>
+				</SegmentTimeline>
+			</SegmentTemplate>
+			<Representation id="root_video4"
+			                bandwidth="769600"
+			                codecs="hvc1.2.4.L93.B0"
+			                width="512"
+			                height="288"
+			                frameRate="30000/1001"/>
+		</AdaptationSet>
+		<!-- HD Adaptation Set (keyID: 65ee94f8-54db-4460-ae6d-401bf195fc2b) -->
+		<AdaptationSet id="11"
+		               contentType="video"
+		               mimeType="video/mp4"
+		               segmentAlignment="true"
+		               startWithSAP="1">
+			<ContentProtection schemeIdUri="urn:mpeg:dash:mp4protection:2011"
+			                   value="cenc"
+			                   cenc:default_KID="65ee94f8-54db-4460-ae6d-401bf195fc2b"/>
+			<ContentProtection schemeIdUri="urn:uuid:afbcb50e-bf74-3d13-be8f-13930c783962"
+			                   robustness="HW_SECURE_CRYPTO">
+				<cenc:pssh>...</cenc:pssh>
+			</ContentProtection>
+			<ContentProtection schemeIdUri="urn:uuid:9a04f079-9840-4286-ab92-e65be0885f95"
+			                   value="MSPR 2.0"
+			                   robustness="SL2000">
+				<cenc:pssh>...</cenc:pssh>
+			</ContentProtection>
+			<!-- Can switch to SD or UHD -->
+			<SupplementalProperty schemeIdUri="urn:mpeg:dash:adaptation-set-switching:2016"
+			                      value="10,12"/>
+			<Accessibility schemeIdUri="urn:scte:dash:cc:cea-608:2015"
+			               value="CC1=eng"/>
+			<Role schemeIdUri="urn:mpeg:dash:role:2011"
+			      value="main"/>
+			<SegmentTemplate initialization="$RepresentationID$/init.mp4"
+			                 media="$RepresentationID$/$Time$.mp4"
+			                 timescale="90000"
+			                 startNumber="807170070"
+			                 presentationTimeOffset="36403">
+				<SegmentTimeline>
+					<S t="6002913283"
+					   d="180180"
+					   r="13"/>
+				</SegmentTimeline>
+			</SegmentTemplate>
+			<Representation id="root_video3"
+			                bandwidth="2282000"
+			                codecs="hvc1.2.4.L120.B0"
+			                width="1280"
+			                height="720"
+			                frameRate="30000/1001"/>
+			<Representation id="root_video2"
+			                bandwidth="7088800"
+			                codecs="hvc1.2.4.L123.B0"
+			                width="1920"
+			                height="1080"
+			                frameRate="30000/1001"/>
+			<Representation id="root_video1"
+			                bandwidth="7088800"
+			                codecs="hvc1.2.4.L123.B0"
+			                width="1920"
+			                height="1080"
+			                frameRate="60000/1001"/>
+		</AdaptationSet>
+		<!-- UHD Adaptation Set (keyID: 100efe5e-247f-4a82-b4ed-cb159f8b7b20) -->
+		<AdaptationSet id="12"
+		               contentType="video"
+		               mimeType="video/mp4"
+		               segmentAlignment="true"
+		               startWithSAP="1">
+			<ContentProtection schemeIdUri="urn:mpeg:dash:mp4protection:2011"
+			                   value="cenc"
+			                   cenc:default_KID="100efe5e-247f-4a82-b4ed-cb159f8b7b20"/>
+			<ContentProtection schemeIdUri="urn:uuid:afbcb50e-bf74-3d13-be8f-13930c783962"
+			                   robustness="HW_SECURE_ALL">
+				<cenc:pssh>...</cenc:pssh>
+			</ContentProtection>
+			<ContentProtection schemeIdUri="urn:uuid:9a04f079-9840-4286-ab92-e65be0885f95"
+			                   value="MSPR 2.0"
+			                   robustness="SL3000">
+				<cenc:pssh>...</cenc:pssh>
+			</ContentProtection>
+			<!-- HDCP Hints -->
+			<OutputProtection schemeIdUri="urn:mpeg:dash:output-protection:hdcp:2020"
+			                  value="2.2"/>
+			<!-- Can switch to SD or HD -->
+			<SupplementalProperty schemeIdUri="urn:mpeg:dash:adaptation-set-switching:2016"
+			                      value="10,11"/>
+			<Role schemeIdUri="urn:mpeg:dash:role:2011"
+			      value="main"/>
+			<SegmentTemplate initialization="$RepresentationID$/init.mp4"
+			                 media="$RepresentationID$/$Time$.mp4"
+			                 timescale="90000"
+			                 startNumber="807170070"
+			                 presentationTimeOffset="36403">
+				<SegmentTimeline>
+					<S t="6002913283"
+					   d="180180"
+					   r="13"/>
+				</SegmentTimeline>
+			</SegmentTemplate>
+			<Representation id="root_video1"
+			                bandwidth="14057200"
+			                codecs="hvc1.2.4.L153.B0"
+			                width="2560"
+			                height="1440"
+			                frameRate="60000/1001"/>
+			<Representation id="root_video0"
+			                bandwidth="20575600"
+			                codecs="hvc1.2.4.L153.B0"
+			                width="3840"
+			                height="2160"
+			                frameRate="60000/1001"/>
+		</AdaptationSet>
+		<!-- E-AC-3 Audio Primary lang (keyID: 55ff04db-d75a-dfb9-ef8a-6473ae9ac9c4) -->
+		<AdaptationSet id="3"
+		               contentType="audio"
+		               mimeType="audio/mp4"
+		               lang="en">
+			<AudioChannelConfiguration schemeIdUri="urn:mpeg:mpegB:cicp:ChannelConfiguration"
+			                           value="6"/>
+			<ContentProtection schemeIdUri="urn:mpeg:dash:mp4protection:2011"
+			                   value="cenc"
+			                   cenc:default_KID="55ff04db-d75a-dfb9-ef8a-6473ae9ac9c4"/>
+			<ContentProtection schemeIdUri="urn:uuid:afbcb50e-bf74-3d13-be8f-13930c783962"
+			                   robustness="SW_SECURE_CRYPTO">
+				<cenc:pssh>...</cenc:pssh>
+			</ContentProtection>
+			<ContentProtection schemeIdUri="urn:uuid:9a04f079-9840-4286-ab92-e65be0885f95"
+			                   value="MSPR 2.0"
+			                   robustness="SL2000">
+				<cenc:pssh>...</cenc:pssh>
+			</ContentProtection>
+			<Role schemeIdUri="urn:mpeg:dash:role:2011"
+			      value="main"/>
+			<SegmentTemplate initialization="$RepresentationID$/init.mp4"
+			                 media="$RepresentationID$/$Time$.mp4"
+			                 timescale="90000"
+			                 startNumber="807170070"
+			                 presentationTimeOffset="36403">
+				<SegmentTimeline>
+					<S t="6002915623"
+					   d="178560"
+					   r="0"/>
+					<S t="6003094183"
+					   d="181440"
+					   r="0"/>
+					<S t="6003275623"
+					   d="178560"
+					   r="0"/>
+					<S t="6003454183"
+					   d="181440"
+					   r="0"/>
+					<S t="6003635623"
+					   d="178560"
+					   r="0"/>
+					<S t="6003814183"
+					   d="181440"
+					   r="1"/>
+					<S t="6004177063"
+					   d="178560"
+					   r="0"/>
+					<S t="6004355623"
+					   d="181440"
+					   r="0"/>
+					<S t="6004537063"
+					   d="178560"
+					   r="0"/>
+					<S t="6004715623"
+					   d="181440"
+					   r="0"/>
+					<S t="6004897063"
+					   d="178560"
+					   r="0"/>
+					<S t="6005075623"
+					   d="181440"
+					   r="1"/>
+				</SegmentTimeline>
+			</SegmentTemplate>
+			<Representation id="root_audio66"
+			                bandwidth="288000"
+			                codecs="ec-3"
+			                audioSamplingRate="48000"/>
+		</AdaptationSet>
+		<!-- Same as previous audio -->
+		<AdaptationSet id="4"
+		               contentType="audio"
+		               mimeType="audio/mp4"
+		               lang="en">
+			<AudioChannelConfiguration schemeIdUri="urn:mpeg:mpegB:cicp:ChannelConfiguration"
+			                           value="2"/>
+			<ContentProtection schemeIdUri="urn:mpeg:dash:mp4protection:2011"
+			                   value="cenc"
+			                   cenc:default_KID="55ff04db-d75a-dfb9-ef8a-6473ae9ac9c4"/>
+			<ContentProtection schemeIdUri="urn:uuid:afbcb50e-bf74-3d13-be8f-13930c783962"
+			                   robustness="SW_SECURE_CRYPTO">
+				<cenc:pssh>...</cenc:pssh>
+			</ContentProtection>
+			<ContentProtection schemeIdUri="urn:uuid:9a04f079-9840-4286-ab92-e65be0885f95"
+			                   value="MSPR 2.0"
+			                   robustness="SL2000">
+				<cenc:pssh>...</cenc:pssh>
+			</ContentProtection>
+			<Role schemeIdUri="urn:mpeg:dash:role:2011"
+			      value="main"/>
+			<SegmentTemplate initialization="$RepresentationID$/init.mp4"
+			                 media="$RepresentationID$/$Time$.mp4"
+			                 timescale="90000"
+			                 startNumber="807170070"
+			                 presentationTimeOffset="36403">
+				<SegmentTimeline>
+					<S t="6002916699"
+					   d="180480"
+					   r="0"/>
+					<S t="6003097179"
+					   d="176640"
+					   r="0"/>
+					<S t="6003273819"
+					   d="180480"
+					   r="11"/>
+				</SegmentTimeline>
+			</SegmentTemplate>
+			<Representation id="root_audio67"
+			                bandwidth="182400"
+			                codecs="mp4a.40.5"
+			                audioSamplingRate="24000"/>
+		</AdaptationSet>
+		<!-- Same as previous audio -->
+		<AdaptationSet id="5"
+		               contentType="audio"
+		               mimeType="audio/mp4"
+		               lang="en">
+			<AudioChannelConfiguration schemeIdUri="urn:mpeg:mpegB:cicp:ChannelConfiguration"
+			                           value="2"/>
+			<ContentProtection schemeIdUri="urn:mpeg:dash:mp4protection:2011"
+			                   value="cenc"
+			                   cenc:default_KID="55ff04db-d75a-dfb9-ef8a-6473ae9ac9c4"/>
+			<ContentProtection schemeIdUri="urn:uuid:afbcb50e-bf74-3d13-be8f-13930c783962"
+			                   robustness="SW_SECURE_CRYPTO">
+				<cenc:pssh>...</cenc:pssh>
+			</ContentProtection>
+			<ContentProtection schemeIdUri="urn:uuid:9a04f079-9840-4286-ab92-e65be0885f95"
+			                   value="MSPR 2.0">
+				<cenc:pssh>...</cenc:pssh>
+			</ContentProtection>
+			<Role schemeIdUri="urn:mpeg:dash:role:2011"
+			      value="dub"/>
+			<SegmentTemplate initialization="$RepresentationID$/init.mp4"
+			                 media="$RepresentationID$/$Time$.mp4"
+			                 timescale="90000"
+			                 startNumber="807170070"
+			                 presentationTimeOffset="36403">
+				<SegmentTimeline>
+					<S t="6002915623"
+					   d="178560"
+					   r="0"/>
+					<S t="6003094183"
+					   d="181440"
+					   r="0"/>
+					<S t="6003275623"
+					   d="178560"
+					   r="0"/>
+					<S t="6003454183"
+					   d="181440"
+					   r="0"/>
+					<S t="6003635623"
+					   d="178560"
+					   r="0"/>
+					<S t="6003814183"
+					   d="181440"
+					   r="1"/>
+					<S t="6004177063"
+					   d="178560"
+					   r="0"/>
+					<S t="6004355623"
+					   d="181440"
+					   r="0"/>
+					<S t="6004537063"
+					   d="178560"
+					   r="0"/>
+					<S t="6004715623"
+					   d="181440"
+					   r="0"/>
+					<S t="6004897063"
+					   d="178560"
+					   r="0"/>
+					<S t="6005075623"
+					   d="181440"
+					   r="1"/>
+				</SegmentTimeline>
+			</SegmentTemplate>
+			<Representation id="root_audio68"
+			                bandwidth="182400"
+			                codecs="ec-3"
+			                audioSamplingRate="48000"/>
+		</AdaptationSet>
+	</Period>
+</MPD>

--- a/xml/README.md
+++ b/xml/README.md
@@ -13,3 +13,5 @@ space prefixes.
 This package is a copy of PR#48641. More specifically, commit f68da8a.
 
 Hopefully, this code will be merged into the Go standard library at some point.
+
+Escaping tab and newline led to problems with some DASHSchema test content so this disabled.

--- a/xml/marshal_test.go
+++ b/xml/marshal_test.go
@@ -2079,11 +2079,11 @@ var encodeTokenTests = []struct {
 	},
 	want: `foo`,
 }, {
-	desc: "char data with escaped chars",
+	desc: "char data but tab and newline not escaped",
 	toks: []Token{
 		CharData(" \t\n"),
 	},
-	want: " &#x9;\n",
+	want: " \t\n",
 }, {
 	desc: "comment",
 	toks: []Token{

--- a/xml/xml.go
+++ b/xml/xml.go
@@ -1927,7 +1927,7 @@ var (
 // EscapeText writes to w the properly escaped XML equivalent
 // of the plain text data s.
 func EscapeText(w io.Writer, s []byte) error {
-	return escapeText(w, s, true)
+	return escapeText(w, s, false)
 }
 
 // escapeText writes to w the properly escaped XML equivalent
@@ -1950,8 +1950,6 @@ func escapeText(w io.Writer, s []byte, escapeNewline bool) error {
 			esc = escLT
 		case '>':
 			esc = escGT
-		case '\t':
-			esc = escTab
 		case '\n':
 			if !escapeNewline {
 				continue


### PR DESCRIPTION
Added `<SelectionInfo>` element from 5th Edition Amendment 1.

This makes `<Event>` having mixed type with both text and daughter elements.

Added DASHSchema test content G23-G27.

Fixed `<Event>` element text part.

Resolves #29