### PR TITLE
feat: DASH Ed 6 elements and new test content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Nothing yet
+### Changed
+
+- Duration is now printed with millisecond accuracy unless value less than one millisecond
+- PatchLocationType according to Ed. 6
+- Location according to Ed. 6
+
+### Added
+
+- All elements according to DASH Ed. 6 contribution to Jan. 2025 MPEG meeting
+- AlternativeMPD element according to Ed. 6
+- ContentSteering according to Ed. 6
+- ClientDataReporting according to Ed. 6
+- SegmentSequenceProperties according to Ed. 6
+- RunLengthType according to Ed. 6
+- Pattern and PatternType according to Ed. 6
+- SupVideoInfoType according to Ed. 6 xsd
+- SapWithCadenceType according to Ed. 6
+- Example DASHSchema content G.23 to G28.1, G28.2, and G.29
+- Example DASGSchema content G.30-1 to G.30-5, G.31-1, G.31-2, G.32-1, G.32-2
 
 ## [0.12.0] - 2024-12-20
 

--- a/mpd/duration_test.go
+++ b/mpd/duration_test.go
@@ -63,3 +63,23 @@ func TestParseBadDurations(t *testing.T) {
 		require.EqualError(t, err, msg, fmt.Sprintf("Expected an error for: %s", ins))
 	}
 }
+
+func TestUnMarshalReMarshalDuration(t *testing.T) {
+	cases := []string{
+		"PT0.0002S",
+		"PT0.334S",
+		"PT2.002S",
+		"PT2S",
+		"PT1M",
+		"PT0S",
+	}
+
+	for _, dur := range cases {
+		timeDur, err := ParseDuration(dur)
+		require.NoError(t, err)
+
+		tDur := Duration(timeDur)
+		outDur := tDur.String()
+		require.Equal(t, dur, outDur)
+	}
+}

--- a/mpd/mpd_test.go
+++ b/mpd/mpd_test.go
@@ -68,6 +68,32 @@ func TestDecodeEncodeMPDs(t *testing.T) {
 	}
 }
 
+func TestExtUrlQueryInfo(t *testing.T) {
+
+	cases := []struct {
+		name  string
+		input string
+	}{
+		{
+			name: "example_G31.1 ExtUrlQueryInfo",
+			input: `<EssentialProperty schemeIdUri="urn:mpeg:dash:urlparam:2016"
+	xmlns:up="urn:mpeg:dash:schema:urlparam:2016">
+	<up:ExtUrlQueryInfo includeInRequests="altmpd"
+		queryTemplate="prta=$urn:mpeg:dash:state:execution-delta#42$" />
+</EssentialProperty>`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ep := m.DescriptorType{}
+			err := xml.Unmarshal([]byte(tc.input), &ep)
+			require.NoError(t, err)
+
+		})
+	}
+}
+
 func BenchmarkUnmarshal(b *testing.B) {
 	data, err := os.ReadFile("testdata/schema-mpds/example_G15.mpd")
 	require.NoError(b, err)

--- a/mpd/testdata/go-dash-fixtures/truncate.mpd
+++ b/mpd/testdata/go-dash-fixtures/truncate.mpd
@@ -40,7 +40,7 @@
       </Representation>
     </AdaptationSet>
   </Period>
-  <Period id="1" start="PT31.421333333S">
+  <Period id="1" start="PT31.421S">
     <AdaptationSet frameRate="90000/3000" id="0" segmentAlignment="true" maxWidth="720" contentType="video">
       <Representation sar="1:1" mimeType="video/mp4" bandwidth="311792" codecs="avc1.42c01e" height="480" id="0" width="720">
         <SegmentTemplate initialization="video_0/init.mp4" media="video_0/media_$Number$.m4s" startNumber="6" timescale="90000">

--- a/mpd/testdata/go-dash-fixtures/truncate_short.mpd
+++ b/mpd/testdata/go-dash-fixtures/truncate_short.mpd
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <MPD xmlns="urn:mpeg:dash:schema:mpd:2011" profiles="urn:mpeg:dash:profile:isoff-live:2011" type="dynamic" minBufferTime="PT2S" availabilityStartTime="2019-12-03T20:57:14Z" minimumUpdatePeriod="PT5S" publishTime="2019-12-03T21:05:05Z" timeShiftBufferDepth="PT2M">
-  <Period id="1" start="PT31.421333333S">
+  <Period id="1" start="PT31.421S">
     <AdaptationSet frameRate="90000/3000" id="0" segmentAlignment="true" maxWidth="720" contentType="video">
       <Representation sar="1:1" mimeType="video/mp4" bandwidth="311792" codecs="avc1.42c01e" height="480" id="0" width="720">
         <SegmentTemplate initialization="video_0/init.mp4" media="video_0/media_$Number$.m4s" startNumber="6" timescale="90000">

--- a/mpd/testdata/livesim/urlparams.mpd
+++ b/mpd/testdata/livesim/urlparams.mpd
@@ -10,7 +10,7 @@ publishTime="1970-01-01T00:00:00Z" timeShiftBufferDepth="PT5M" type="dynamic" xs
 <Period id="p0" start="PT0S">
       <AdaptationSet contentType="audio" lang="en" mimeType="audio/mp4" segmentAlignment="true" startWithSAP="1">
         <EssentialProperty schemeIdUri="urn:mpeg:dash:urlparam:2016" xmlns:up="urn:mpeg:dash:schema:urlparam:2016">
-            <up:ExtendedUrlInfo queryTemplate="$querypart$" useMPDUrlQuery="true" headerParamSource="dashif.org"/>
+            <up:ExtUrlQueryInfo queryTemplate="$querypart$" useMPDUrlQuery="true" headerParamSource="dashif.org"/>
         </EssentialProperty>
          <Role schemeIdUri="urn:mpeg:dash:role:2011" value="main" />
          <SegmentTemplate duration="2" initialization="$RepresentationID$/init.mp4" media="$RepresentationID$/$Number$.m4s" startNumber="0" />

--- a/mpd/testdata/schema-mpds/example_G28.1.mpd
+++ b/mpd/testdata/schema-mpds/example_G28.1.mpd
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<MPD xmlns="urn:mpeg:dash:schema:mpd:2011" type="dynamic" id="7399610060681366163" profiles="urn:mpeg:dash:profile:isoff-live:2011" minBufferTime="PT2.002S" maxSegmentDuration="PT2.002S" minimumUpdatePeriod="PT2.002S"
+availabilityStartTime="1977-05-25T18:00:00.000Z" timeShiftBufferDepth="PT30S"
+publishTime="2023-11-10T20:44:07.025Z"
+xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:mpeg:dash:schema:mpd:2011 DASH-MPD.xsd">
+
+    <Period id="817467999" start="PT389761H2M15.535S">
+
+        <AdaptationSet id="1" contentType="video" mimeType="video/mp4" segmentAlignment="true" startWithSAP="1">
+            <SupplementalProperty schemeIdUri="urn:mpeg:dash:adaptation-set-switching:2016" value="video_fga"/>
+            <Role schemeIdUri="urn:mpeg:dash:role:2011" value="main"/>
+
+            <SegmentTemplate initialization="$RepresentationID$/init.mp4" timeShiftBufferDepth="PT30S"
+                media="$RepresentationID$/segment_$Time$.mp4" timescale="90000" presentationTimeOffset="135158">
+
+                <SegmentTimeline>
+                    <S t="546975158" d="172800" r="144"/>
+                </SegmentTimeline>
+
+            </SegmentTemplate>
+
+            <Representation id="540p"  bandwidth="1502000"
+                      codecs="hvc1.2.4.L93.B0"  width="960"  height="540"  frameRate="50"/>
+            <Representation id="720p"  bandwidth="2166000"
+                      codecs="hvc1.2.4.L93.B0"  width="1280" height="720"  frameRate="50"/>
+            <Representation id="1080p" bandwidth="6202000"
+                      codecs="hvc1.2.4.L123.B0" width="1920" height="1080" frameRate="50"/>
+            <Representation id="1440p" bandwidth="12741200"
+                      codecs="hvc1.2.4.L153.B0" width="2560" height="1440" frameRate="50"/>
+            <Representation id="2160p" bandwidth="18667200"
+                      codecs="hvc1.2.4.H153.B0" width="3840" height="2160" frameRate="50"/>
+
+        </AdaptationSet>
+
+        <AdaptationSet id="11" contentType="video" mimeType="video/mp4"
+                       segmentAlignment="true" startWithSAP="1">
+            <EssentialProperty
+                       schemeIdUri="urn:mpeg:dash:ssr:2023" value="video_primary"/>
+            <SupplementalProperty schemeIdUri="urn:mpeg:dash:adaptation-set-switching:2016"
+                       value="video_primary"/>
+
+
+            <SegmentTemplate initialization="$RepresentationID$/init.mp4"
+                media="$RepresentationID$/segment_$Time$_part_$SubNumber$.mp4"
+                timescale="90000" presentationTimeOffset="135158">
+
+                <SegmentTimeline>
+                    <S t="546975158" d="172800" r="144" k="16"/>
+                </SegmentTimeline>
+
+            </SegmentTemplate>
+
+            <!-- Fine Granularity Access representations with 6-frame partial segments.
+           Each segment starts with IDR and can be used to start playback  -->
+            <Representation id="join_6_540p"   bandwidth="600000"
+                      codecs="hvc1.2.4.L93.B0"  width="960"   height="540"  frameRate="50"/>
+            <Representation id="join_6_1080p"  bandwidth="1200000"
+                     codecs="hvc1.2.4.L93.B0"  width="1920"  height="1080"  frameRate="50"/>
+
+        </AdaptationSet>
+
+    </Period>
+
+</MPD>

--- a/mpd/testdata/schema-mpds/example_G28.2.mpd
+++ b/mpd/testdata/schema-mpds/example_G28.2.mpd
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<MPD xmlns="urn:mpeg:dash:schema:mpd:2011" type="dynamic" id="7399610060681366163" profiles="urn:mpeg:dash:profile:isoff-live:2011" minBufferTime="PT2S" maxSegmentDuration="PT2.016S" minimumUpdatePeriod="PT2.002S" availabilityStartTime="1977-05-25T18:00:00.000Z" timeShiftBufferDepth="PT30S" publishTime="2021-11-10T20:44:07.025Z"
+xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:mpeg:dash:schema:mpd:2011 DASH-MPD.xsd">
+
+    <ServiceDescription id="0">
+		   <Latency min="750" max="4200" target="1250" referenceId="7"/>
+		   <PlaybackRate min="0.96" max="1.04"/>
+    </ServiceDescription>
+
+    <Period id="817467999" start="PT389761H2M15.535S">
+
+    <AdaptationSet id="1" contentType="video" mimeType="video/mp4"
+                   segmentAlignment="true">
+
+      <EssentialProperty schemeIdUri="urn:mpeg:dash:ssr:2023" />
+
+	  <ProducerReferenceTime id="7" wallClockTime="2019-08-06T13:44:12Z"
+				   presentationTime="158400"/>
+
+      <!-- Segment Sequence Representations where partial segments with subnumber > 1
+         are not expected to have any kind of random access / bitstream switching
+         The first partial segment starts with SAP = 1 -->
+
+      <SegmentSequenceProperties>
+         <SAP type="1"/>
+      </SegmentSequenceProperties>
+
+      <Role schemeIdUri="urn:mpeg:dash:role:2011" value="main"/>
+
+      <SegmentTemplate initialization="$RepresentationID$/init.mp4"
+                       media="$RepresentationID$/segment_$Number$_part_$SubNumber$.mp4"
+                       timescale="90000" startNumber="817472154"
+                       presentationTimeOffset="135158">
+
+        <SegmentTimeline>
+          <!-- 1.92s segment with 6-frame partial segments, compatible with LL-HLS-->
+          <S t="546975158" d="172800" r="14" k="16"/>
+        </SegmentTimeline>
+
+      </SegmentTemplate>
+
+      <Representation id="l3d_540p"  bandwidth="1502000"  codecs="hvc1.2.4.L93.B0"
+                      width="960"  height="540"  frameRate="50"/>
+      <Representation id="l3d_720p"  bandwidth="2166000"  codecs="hvc1.2.4.L93.B0"
+                      width="1280" height="720"  frameRate="50"/>
+      <Representation id="l3d_1080p" bandwidth="6202000"  codecs="hvc1.2.4.L123.B0"
+                      width="1920" height="1080" frameRate="50"/>
+      <Representation id="l3d_1440p" bandwidth="12741200" codecs="hvc1.2.4.L153.B0"
+                      width="2560" height="1440" frameRate="50"/>
+      <Representation id="l3d_2160p" bandwidth="18667200" codecs="hvc1.2.4.H153.B0"
+                      width="3840" height="2160" frameRate="50"/>
+
+    </AdaptationSet>
+
+  </Period>
+
+</MPD>

--- a/mpd/testdata/schema-mpds/example_G29.mpd
+++ b/mpd/testdata/schema-mpds/example_G29.mpd
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<MPD xmlns="urn:mpeg:dash:schema:mpd:2011" type="dynamic" id="7399610060681366163" profiles="urn:mpeg:dash:profile:isoff-live:2011"
+    minBufferTime="PT2S" maxSegmentDuration="PT2.016S" minimumUpdatePeriod="PT2.002S"
+    timeShiftBufferDepth="PT30S" publishTime="2021-11-10T20:44:07.025Z"
+    availabilityStartTime="1977-05-25T18:00:00.000Z"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:mpeg:dash:schema:mpd:2011 DASH-MPD.xsd">
+
+    <Period id="817467999" start="PT389761H2M15.535S">
+        <AdaptationSet id="1" contentType="audio" mimeType="audio/mp4" segmentAlignment="true"
+            startWithSAP="1" audioSamplingRate="24000">
+
+            <EssentialProperty schemeIdUri="urn:mpeg:dash:pattern:2024"/>
+
+            <Role schemeIdUri="urn:mpeg:dash:role:2011" value="main"/>
+
+            <SegmentTemplate initialization="$RepresentationID$/init.mp4"
+                media="$RepresentationID$/segment_$Time$.mp4" timescale="90000"
+                startNumber="817472154" presentationTimeOffset="135158">
+
+                <SegmentTimeline>
+                    <Pattern id="1">
+                        <P d="180480" r="11"/>
+                        <P d="176640"/>
+                    </Pattern>
+                    <S t="546975158" r="164" p="1" pE="3" d="0"/>
+                </SegmentTimeline>
+
+            </SegmentTemplate>
+
+            <Representation id="eng_2ch" bandwidth="112000" codecs="mp4a.40.5"/>
+
+        </AdaptationSet>
+
+    </Period>
+</MPD>
+

--- a/mpd/testdata/schema-mpds/example_G30-1.mpd
+++ b/mpd/testdata/schema-mpds/example_G30-1.mpd
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<MPD
+xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+xmlns="urn:mpeg:dash:schema:mpd:2011"
+xsi:schemaLocation="urn:mpeg:dash:schema:mpd:2011 DASH-MPD.xsd urn:mpeg:dash:schema:urlparam:2014 DASH-MPD-UP.xsd"
+
+type="static" mediaPresentationDuration="PT54M16S" minBufferTime="PT1.2S" profiles="urn:mpeg:dash:profile:isoff-on-demand:2011">
+	<Period>
+		<AdaptationSet mimeType="video/mp4" segmentAlignment="true" startWithSAP="1" maxWidth="1280" maxHeight="720" maxFrameRate="25" par="16:9">
+			<EssentialProperty schemeIdUri="urn:mpeg:dash:urlparam:2014" xmlns:up="urn:mpeg:dash:schema:urlparam:2014">
+				<up:UrlQueryInfo queryTemplate="$querypart$" useMPDUrlQuery="true"/>
+			</EssentialProperty>
+			<SegmentTemplate duration="2" startNumber="1" media="video_$Number$_$Bandwidth$bps.mp4"/>
+			<Representation id="v0" codecs="avc3.4d401f" width="1280" height="720" frameRate="25" sar="1:1" bandwidth="3000000"/>
+			<Representation id="v1" codecs="avc3.4d401f" width="640" height="360" frameRate="25" sar="1:1" bandwidth="1500000"/>
+		</AdaptationSet>
+	</Period>
+</MPD>

--- a/mpd/testdata/schema-mpds/example_G30-2.mpd
+++ b/mpd/testdata/schema-mpds/example_G30-2.mpd
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<MPD xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="urn:mpeg:dash:schema:mpd:2011" xsi:schemaLocation="urn:mpeg:dash:schema:mpd:2011 DASH-MPD.xsd urn:mpeg:dash:schema:urlparam:2014 DASH-MPD-UP.xsd" type="static" mediaPresentationDuration="PT54M16S" minBufferTime="PT1.2S" profiles="urn:mpeg:dash:profile:isoff-on-demand:2011">
+	<Period>
+		<AdaptationSet mimeType="video/mp4" segmentAlignment="true" startWithSAP="1" maxWidth="1280" maxHeight="720" maxFrameRate="25" par="16:9">
+			<EssentialProperty schemeIdUri="urn:mpeg:dash:urlparam:2014" xmlns:up="urn:mpeg:dash:schema:urlparam:2014">
+				<up:UrlQueryInfo xlink:href="http://www.example.com/dash/xlinked.mpd" xlink:actuate="onRequest" xmlns:xlink="http://www.w3.org/1999/xlink"/>
+			</EssentialProperty>
+			<SegmentTemplate duration="2" startNumber="1" media="video_$Number$_$Bandwidth$bps.mp4"/>
+ 			<Representation id="v0" codecs="avc3.4d401f" width="1280" height="720" frameRate="25" sar="1:1" bandwidth="3000000"/>
+			<Representation id="v1" codecs="avc3.4d401f" width="640" height="360" frameRate="25" sar="1:1" bandwidth="1500000"/>
+		</AdaptationSet>
+		<SupplementalProperty schemeIdUri="urn:mpeg:dash:urlparam:2014" xmlns:up="urn:mpeg:dash:schema:urlparam:2014">
+			<up:UrlQueryInfo xmlns:up="urn:mpeg:dash:schema:urlparam:2014" queryTemplate="$querypart$" queryString="param=justintimecomputedvalue"/>
+		</SupplementalProperty>
+	</Period>
+</MPD>

--- a/mpd/testdata/schema-mpds/example_G30-3.mpd
+++ b/mpd/testdata/schema-mpds/example_G30-3.mpd
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<MPD
+xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+xmlns="urn:mpeg:dash:schema:mpd:2011"
+xsi:schemaLocation="urn:mpeg:dash:schema:mpd:2011 DASH-MPD.xsd urn:mpeg:dash:schema:urlparam:2014 DASH-MPD-UP.xsd"
+type="static" mediaPresentationDuration="PT54M16S" minBufferTime="PT1.2S" profiles="urn:mpeg:dash:profile:isoff-on-demand:2011">
+	<Period>
+<AdaptationSet mimeType="video/mp4" segmentAlignment="true" startWithSAP="1" maxWidth="1280" maxHeight="720" maxFrameRate="25" par="16:9">
+  <SupplementalProperty schemeIdUri="urn:mpeg:dash:urlparam:2014" xmlns:up="urn:mpeg:dash:schema:urlparam:2014">
+    <up:UrlQueryInfo queryTemplate="$querypart$" useMPDUrlQuery="true"/>
+  </SupplementalProperty>
+  <SupplementalProperty schemeIdUri="urn:example:gps"/>
+  <SegmentTemplate duration="2" startNumber="1" media="video_$Number$_$Bandwidth$bps.mp4">
+  </SegmentTemplate>
+  <Representation id="v0" codecs="avc3.4d401f" width="1280" height="720" frameRate="25" sar="1:1" bandwidth="3000000"/>
+  <Representation id="v1" codecs="avc3.4d401f" width="640" height="360" frameRate="25" sar="1:1" bandwidth="1500000"/>
+</AdaptationSet>
+	</Period>
+</MPD>

--- a/mpd/testdata/schema-mpds/example_G30-4.mpd
+++ b/mpd/testdata/schema-mpds/example_G30-4.mpd
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<MPD
+xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+xmlns="urn:mpeg:dash:schema:mpd:2011"
+xsi:schemaLocation="urn:mpeg:dash:schema:mpd:2011 DASH-MPD.xsd urn:mpeg:dash:schema:urlparam:2014 DASH-MPD-UP.xsd"
+type="static" mediaPresentationDuration="PT54M16S" minBufferTime="PT1.2S" profiles="urn:mpeg:dash:profile:isoff-on-demand:2011">
+	<Period>
+<AdaptationSet mimeType="video/mp4" segmentAlignment="true" startWithSAP="1" maxWidth="1280" maxHeight="720" maxFrameRate="25" par="16:9">
+  <EssentialProperty schemeIdUri="urn:mpeg:dash:urlparam:2014" xmlns:up="urn:mpeg:dash:schema:urlparam:2014">
+    <up:UrlQueryInfo queryTemplate="token=$query:token$" useMPDUrlQuery="true"/>
+  </EssentialProperty>
+  <SegmentTemplate duration="2" startNumber="1" media="video_$Number$_$Bandwidth$bps.mp4">
+  </SegmentTemplate>
+  <Representation id="v0" codecs="avc3.4d401f" width="1280" height="720" frameRate="25" sar="1:1" bandwidth="3000000"/>
+  <Representation id="v1" codecs="avc3.4d401f" width="640" height="360" frameRate="25" sar="1:1" bandwidth="1500000"/>
+</AdaptationSet>
+	</Period>
+</MPD>

--- a/mpd/testdata/schema-mpds/example_G30-5.mpd
+++ b/mpd/testdata/schema-mpds/example_G30-5.mpd
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<MPD xmlns="urn:mpeg:dash:schema:mpd:2011" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  availabilityStartTime="2022-11-09T17:26:18Z" maxSegmentDuration="PT1.92S" minBufferTime="PT1S"
+  minimumUpdatePeriod="PT1S" profiles="urn:mpeg:dash:profile:isoff-live:2011"
+  publishTime="2022-11-09T18:55:02Z" timeShiftBufferDepth="PT11S" type="dynamic"
+  xsi:schemaLocation="urn:mpeg:dash:schema:mpd:2011 DASH-MPD.xsd urn:mpeg:dash:schema:urlparam:2016 DASH-MPD-UP.xsd">
+
+  <ServiceDescription id="0">
+    <ContentSteering defaultServiceLocation="beta" queryBeforeStart="true">
+      https://steeringservice.com/app/instance1234 </ContentSteering>
+  </ServiceDescription>
+
+  <Period id="P0" start="PT0S">
+
+    <AdaptationSet contentType="video" id="0" mimeType="video/mp4" par="16:9"
+      segmentAlignment="true" startWithSAP="1">
+
+      <Role schemeIdUri="urn:mpeg:dash:role:2011" value="main"/>
+
+      <SegmentTemplate duration="96" startNumber="868757698" timescale="50"
+        initialization="$RepresentationID$-init.mp4" media="$RepresentationID$-$Number$.mp4" />
+
+      <Representation bandwidth="500000" codecs="hvc1.1.6.L63.B0" frameRate="25" height="360" id="0" width="640"/>
+      <Representation bandwidth="1200000" codecs="hvc1.1.6.L93.B0" frameRate="50" height="540" id="1" width="960"/>
+
+    </AdaptationSet>
+
+  </Period>
+
+  <EssentialProperty schemeIdUri="urn:mpeg:dash:urlparam:2016" xmlns:up="urn:mpeg:dash:schema:urlparam:2016">
+    <up:ExtUrlQueryInfo includeInRequests="steering"
+      queryTemplate="$querypart$&amp;_HLS_pathway=$urn:mpeg:dash:service-location$&amp;_HLS_throughput=$urn:mpeg:dash:throughput$"
+      useMPDUrlQuery="true"/>
+  </EssentialProperty>
+
+</MPD>

--- a/mpd/testdata/schema-mpds/example_G31-1.mpd
+++ b/mpd/testdata/schema-mpds/example_G31-1.mpd
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<MPD
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns="urn:mpeg:dash:schema:mpd:2011"
+	profiles="urn:mpeg:dash:profile:advanced-linear:2025"
+	xsi:schemaLocation="urn:mpeg:dash:schema:mpd:2011 DASH-MPD.xsd urn:mpeg:dash:schema:urlparam:2014 DASH-MPD-UP.xsd"
+	type="dynamic" minimumUpdatePeriod="PT2S"
+	timeShiftBufferDepth="PT30M" minBufferTime="PT4S"
+	availabilityStartTime="2023-12-25T12:30:00"
+	publishTime="2023-12-25T12:30:00">
+
+	<BaseURL>http://cdn1.example.com/</BaseURL>
+	<Period id="1">
+		<EventStream schemeIdUri="urn:mpeg:dash:event:alternativeMPD:replace:2025" timescale="90000">
+			<Event presentationTime="3780000" duration="1350000" id="42">
+				<ReplacePresentation
+					uri="http://cdn1.example.com/ad1.mpd?dur=15"
+					earliestResolutionTimeOffset="378000"
+					maxDuration="1350000" clip="true"
+				    serviceDescriptionId="420"/>
+			</Event>
+
+			<ServiceDescription id="420">
+				<EventRestrictions executeOnce="true"/>
+			</ServiceDescription>
+
+			<EssentialProperty schemeIdUri="urn:mpeg:dash:urlparam:2016"
+				xmlns:up="urn:mpeg:dash:schema:urlparam:2016">
+				<up:ExtUrlQueryInfo includeInRequests="altmpd"
+					queryTemplate="prta=$urn:mpeg:dash:state:execution-delta#42$" />
+			</EssentialProperty>
+
+		</EventStream>
+
+		<AdaptationSet mimeType="video/mp4"
+			codecs="avc1.4D401F" frameRate="30000/1001"
+			segmentAlignment="true" startWithSAP="1">
+
+			<SegmentTemplate timescale="90000"
+				initialization="$Bandwidth%/init.mp4v" media="$Bandwidth%/$Time$.mp4v">
+				<SegmentTimeline>
+					<S t="0" d="180180" r="432"/>
+				</SegmentTimeline>
+			</SegmentTemplate>
+			<Representation id="v0" bandwidth="250000" width="320" height="240"/>
+			<Representation id="v1" bandwidth="500000" width="640" height="480"/>
+			<Representation id="v2" bandwidth="1000000" width="960" height="720"/>
+		</AdaptationSet>
+
+	</Period>
+
+</MPD>
+

--- a/mpd/testdata/schema-mpds/example_G31-2.mpd
+++ b/mpd/testdata/schema-mpds/example_G31-2.mpd
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<MPD xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="urn:mpeg:dash:schema:mpd:2011"
+	profiles="urn:mpeg:dash:profile:list:2024"
+	xsi:schemaLocation="urn:mpeg:dash:schema:mpd:2011 DASH-MPD.xsd" type="list" minBufferTime="PT1S"
+	publishTime="2011-12-25T12:30:00">
+
+
+	<BaseURL>http://cdn1.example.com/</BaseURL>
+
+	<Period id="42" duration="PT15S">
+		<ImportedMPD uri="ad0.mpd" earliestResolutionTimeOffset="0"/>
+
+		<EventStream schemeIdUri="urn:mpeg:dash:event:callback:2015" value="1">
+			<Event presentationTime="0">http://example.com/beacon/ad2?time=0</Event>
+			<Event presentationTime="15">http://example.com/beacon/ad2?time=15</Event>
+		</EventStream>
+
+		<ServiceDescription id="420">
+			<PlaybackRestrictions skipAfter="5"/>
+		</ServiceDescription>
+	</Period>
+
+	<Period id="43"  duration="PT15S">
+		<ImportedMPD uri="ad1.mpd" earliestResolutionTimeOffset="42"/>
+	</Period>
+
+	<Period id="44"  duration="PT15S">
+		<ImportedMPD uri="ad2.mpd" earliestResolutionTimeOffset="42"/>
+	</Period>
+</MPD>

--- a/mpd/testdata/schema-mpds/example_G32-1.mpd
+++ b/mpd/testdata/schema-mpds/example_G32-1.mpd
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<MPD
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns="urn:mpeg:dash:schema:mpd:2011"
+  xsi:schemaLocation="urn:mpeg:dash:schema:mpd:2011 DASH-MPD.xsd"
+  type="static" mediaPresentationDuration="PT10M34S" minBufferTime="PT2S" profiles="urn:mpeg:dash:profile:isoff-live:2011" >
+  <Period>
+    <AdaptationSet id="1" contentType="video" width="960" height="540" frameRate="30" subsegmentAlignment="true" par="16:9" >
+      <!-- Only base layer (quarter-resolution) AVC video -->
+      <SupplementalProperty schemeIdUri="urn:mpeg:dash:preselection:2016"/>
+
+      <Representation id="1r1" bandwidth="1510172" codecs="avc1.64001f" mimeType="video/mp4" sar="1:1">
+        <BaseURL>lcevc.mp4</BaseURL>
+        <SegmentBase indexRange="865-1664" timescale="15360">
+          <Initialization range="0-864"/>
+        </SegmentBase>
+      </Representation>
+    </AdaptationSet>
+
+    <!-- Both AVC base and LC-EVC enhancement Layer -->
+    <Preselection id="2" codecs="lvc1" width="1920" height="1080" preselectionComponents="1" selectionPriority="2">
+    </Preselection>
+  </Period>
+</MPD>

--- a/mpd/testdata/schema-mpds/example_G32-2.mpd
+++ b/mpd/testdata/schema-mpds/example_G32-2.mpd
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<MPD
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns="urn:mpeg:dash:schema:mpd:2011"
+  xsi:schemaLocation="urn:mpeg:dash:schema:mpd:2011 DASH-MPD.xsd"
+  type="static" mediaPresentationDuration="PT54M16S" minBufferTime="PT1.2S" profiles="urn:mpeg:dash:profile:isoff-on-demand:2011">
+  <Period>
+    <AdaptationSet id="1" mimeType="video/mp4" segmentAlignment="true" startWithSAP="1" maxWidth="1280" maxHeight="720" maxFrameRate="25" par="16:9">
+      <SupplementalProperty schemeIdUri="urn:mpeg:dash:preselection:2016"/>
+      <SegmentTemplate duration="2" startNumber="1" media="video_$Number$_$Bandwidth$bps.mp4">
+      </SegmentTemplate>
+      <Representation id="v0" codecs="hvc1.2.4.L153.B0" width="1280" height="720" frameRate="25" sar="1:1" bandwidth="3000000"/>
+      <Representation id="v1" codecs="hvc1.2.4.L90.B0" width="640" height="360" frameRate="25" sar="1:1" bandwidth="1500000"/>
+    </AdaptationSet>
+
+    <!-- stereoscopic view, combination of the above -->
+    <Preselection codecs="lhc1" tag="3" preselectionComponents="1" selectionPriority="3">
+      <Role schemeIdUri="urn:mpeg:dash:stereoid:2011" value="l0 r1"/>
+    </Preselection>
+
+  </Period>
+</MPD>
+


### PR DESCRIPTION
Added elements from current Ed 6 draft

- AlternativeMPD element
- ContentSteering element
- ClientDataReporting element
- SegmentSequenceProperties element
- RunLengthType
- Pattern and PatternType
- SupVideoInfoType
- SapWithCadenceType

Changed Duration to round to milliseconds unless time is less than millisecond

The specs should now be stable, so I don't expect any changes beyond bug fixes.

Solves #30 