### PR TITLE
v0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Nothing yet
+
+## [0.12.0] - 2024-12-20
+
 ### Added
 
 - Ed5Amd1 element `<SelectionInfo>` inside mixed XML type `<Event>`
@@ -138,7 +142,8 @@ Lots of convenience functions to create MPDs
 - Tests with well-known MPDs
 - Tweaked XML library to support namespaces
 
-[Unreleased]: https://github.com/Eyevinn/dash-mpd/compare/v0.11.1...HEAD
+[Unreleased]: https://github.com/Eyevinn/dash-mpd/compare/v0.12.0...HEAD
+[0.12.0]: https://github.com/Eyevinn/dash-mpd/compare/v0.11.1...v0.12.0
 [0.11.1]: https://github.com/Eyevinn/dash-mpd/compare/v0.11.0...v0.11.1
 [0.11.0]: https://github.com/Eyevinn/dash-mpd/compare/v0.10.0...v0.11.0
 [0.10.0]: https://github.com/Eyevinn/dash-mpd/compare/v0.9.1...v0.10.0


### PR DESCRIPTION
### Added

- Ed5Amd1 element `<SelectionInfo>` inside mixed XML type `<Event>`
- UrlQueryInfo and ExtUrlQueryInfo from MPEG-DASH part 1 Annex I

### Fixed

- Updated the G16 example
- Avoid escaping XML tab and newline in text to align with DASHSchema test content
- Handle text inside `<Event>`element

### Chore

- Updated dependencies