### PR TITLE
docs: v0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Nothing yet
+
+## [0.13.0] - 2025-07-28
+
 ### Changed
 
 - Updated golangci-lint and added Makefile
@@ -162,7 +166,8 @@ Lots of convenience functions to create MPDs
 - Tests with well-known MPDs
 - Tweaked XML library to support namespaces
 
-[Unreleased]: https://github.com/Eyevinn/dash-mpd/compare/v0.12.0...HEAD
+[Unreleased]: https://github.com/Eyevinn/dash-mpd/compare/v0.13.0...HEAD
+[0.13.0]: https://github.com/Eyevinn/dash-mpd/compare/v0.12.0...v0.13.0
 [0.12.0]: https://github.com/Eyevinn/dash-mpd/compare/v0.11.1...v0.12.0
 [0.11.1]: https://github.com/Eyevinn/dash-mpd/compare/v0.11.0...v0.11.1
 [0.11.0]: https://github.com/Eyevinn/dash-mpd/compare/v0.10.0...v0.11.0


### PR DESCRIPTION
### Changed

- Updated golangci-lint and added Makefile
- Duration is now printed with millisecond accuracy unless value less than one millisecond
- PatchLocationType according to Ed. 6
- Location according to Ed. 6


### Added

- All elements according to DASH Ed. 6 contribution to Jan. 2025 MPEG meeting
- AlternativeMPD element according to Ed. 6
- ContentSteering according to Ed. 6
- ClientDataReporting according to Ed. 6
- SegmentSequenceProperties according to Ed. 6
- RunLengthType according to Ed. 6
- Pattern and PatternType according to Ed. 6
- SupVideoInfoType according to Ed. 6 xsd
- SapWithCadenceType according to Ed. 6
- Example DASHSchema content G.23 to G28.1, G28.2, and G.29
- Example DASGSchema content G.30-1 to G.30-5, G.31-1, G.31-2, G.32-1, G.32-2