### PR TITLE
perf: xml/mpd optimizations on top of DASH Ed.6 schema refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   limit) and several panic fixes. The local customization that disables tab/
   newline escaping in `CharData` byte content is preserved.
 
+### Performance
+
+- Major reduction in allocations and CPU on the XML marshal/unmarshal hot
+  paths (#2–#12 in `discovery/performance_plan.md`). Includes a pooled
+  `*xml.Encoder` (`AcquireEncoder`/`ReleaseEncoder`), an O(1) attribute
+  lookup map on `typeInfo`, cached `reflect.Type.Implements` results, a
+  per-`Decoder` name-intern map, and streaming `(*MPD).Write`.
+
 ### Removed
 
 - EventRestrictionsType (its executeOnce/noJump/skipAfter attributes are
@@ -37,6 +45,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - ServiceDescription element on EventStream
 - kL and sspL attributes (dropped in Ed. 6)
 - Pattern field on SegmentTemplateType (Pattern lives on SegmentTimeline)
+- Regex-based duration parser (`xmlDurationRegex` and helpers); replaced by
+  a single-pass scanner with stricter validation and zero allocations.
+- Linear attribute-matching loop in `xml/read.go`; replaced by O(1) map
+  lookup.
+- Repeated `typ.Implements(...)` calls in `xml/marshal.go`; replaced by a
+  `sync.Map`-cached result per `reflect.Type`.
+- `xml.MarshalIndent` round-trip inside `(*MPD).Write`; replaced by direct
+  streaming through a pooled encoder.
 
 ## [0.14.1] - 2026-02-06
 

--- a/discovery/performance_plan.md
+++ b/discovery/performance_plan.md
@@ -1,0 +1,1135 @@
+# Performance Improvement Plan: dash-mpd
+
+This plan turns the findings of `discovery/performance_report.md` into a
+concrete, ordered set of implementable tasks. It is written for a junior
+developer: each task lists what to change, which files and line ranges
+to touch, how to verify correctness, and how to measure the impact.
+
+The work is split into 11 independent steps. Land them as separate PRs
+(or at least separate commits) in the order given, so each change can be
+measured against the previous one. **Never land more than one
+performance-impacting change per commit** — otherwise you can't tell
+which one helped.
+
+---
+
+## 0. Preflight: set up a repeatable measurement workflow
+
+Before touching any code, make sure you can reliably measure the
+benchmarks. Every step below is gated on "did the numbers get better?".
+
+1. Create a working branch:
+
+   ```sh
+   git switch -c perf-h1-through-hN   # pick a name per step
+   ```
+
+2. Record the baseline on `main` (or current `perf-audit`) **once**:
+
+   ```sh
+   git switch main
+   go test ./mpd -run=^$ -bench=Unmarshal\|Marshal \
+       -benchmem -benchtime=5s -count=10 \
+       > /tmp/dash-mpd-baseline.txt
+   ```
+
+   The `-count=10` gives `benchstat` enough samples to compute a mean
+   and confidence interval. `-run=^$` disables unit tests during the
+   bench run. We exclude `BenchmarkClone` from `-bench=` because it
+   currently crashes (see step 1).
+
+3. Install `benchstat` if you don't already have it:
+
+   ```sh
+   go install golang.org/x/perf/cmd/benchstat@latest
+   ```
+
+4. For every subsequent change, generate a new result file and compare:
+
+   ```sh
+   go test ./mpd -run=^$ -bench=Unmarshal\|Marshal \
+       -benchmem -benchtime=5s -count=10 \
+       > /tmp/dash-mpd-after.txt
+   benchstat /tmp/dash-mpd-baseline.txt /tmp/dash-mpd-after.txt
+   ```
+
+5. Correctness gate on every step: `go test ./...` must pass. In
+   particular `TestDecodeEncodeMPDs` (in `mpd/mpd_test.go:22`) is the
+   round-trip regression test — it parses every MPD in `mpd/testdata/`
+   and re-serialises it, checking that the result is semantically
+   identical. It will catch almost any behaviour regression in the
+   `xml/` package.
+
+Keep the baseline file around for the whole project; the "cumulative
+effect" at the end is measured against it, not against the previous
+step.
+
+---
+
+## 1. Fix `BenchmarkClone` so the full bench suite runs (H10)
+
+**Why first:** without this, `go test -bench=.` aborts with a stack
+overflow, and you can't run all three benchmarks in the same command.
+Not a performance win by itself, but it unblocks everything else.
+
+**File:** `mpd/mpd_test.go:118-129`
+
+**Current code:**
+
+```go
+func BenchmarkClone(b *testing.B) {
+    data, err := os.ReadFile("testdata/schema-mpds/example_G15.mpd")
+    require.NoError(b, err)
+    mpd := m.MPD{}
+    err = xml.Unmarshal(data, &mpd)
+    require.NoError(b, err)
+    mpdCopy := m.Clone(&mpd)
+    cmp.Equal(&mpd, mpdCopy)          // <-- crashes: infinite recursion via parent back-pointer
+    for i := 0; i < b.N; i++ {
+        _ = m.Clone(&mpd)
+    }
+}
+```
+
+**Steps:**
+
+1. Delete the `mpdCopy := m.Clone(&mpd)` and `cmp.Equal(&mpd, mpdCopy)`
+   lines. They are outside the timed loop and do nothing useful. They
+   are the direct cause of the stack overflow: `cmp.Equal` walks the
+   whole struct tree and follows `parent *MPD` pointers set by
+   `SetParents()`, which creates infinite recursion.
+2. The benchmark does **not** call `mpd.SetParents()`, which means
+   `m.Clone` runs against a tree without parent back-pointers. That's
+   fine for measuring clone cost. Leave it off.
+3. If the `go-cmp` import becomes unused, remove it from the import
+   block.
+
+**Result after:**
+
+```go
+func BenchmarkClone(b *testing.B) {
+    data, err := os.ReadFile("testdata/schema-mpds/example_G15.mpd")
+    require.NoError(b, err)
+    mpd := m.MPD{}
+    err = xml.Unmarshal(data, &mpd)
+    require.NoError(b, err)
+    for i := 0; i < b.N; i++ {
+        _ = m.Clone(&mpd)
+    }
+}
+```
+
+**Verify:**
+
+```sh
+go test ./mpd -run=^$ -bench=Clone -benchmem -benchtime=1s
+```
+
+Should report a number instead of crashing. Commit.
+
+---
+
+## 2. Rewrite `mpd.ParseDuration` to remove regex (H1)
+
+**Why:** The current implementation runs the same regex twice per call
+(`Match` then `FindStringSubmatch`), copies the input to `[]byte`,
+allocates a 5-element `[]string` plus internal regex state, and then
+makes another round of allocations via `strings.TrimRight` +
+`strconv.Atoi`. Profile share: ~3.4 % of unmarshal alloc_space on a
+small MPD; scales with attribute count on live MPDs.
+
+**File:** `mpd/duration.go:180-231`
+
+**Grammar we must parse** (XSD duration subset that this library
+accepts):
+
+```
+P[nD][T[nH][nM][n(.n)?S]]
+```
+
+- Must start with `P`.
+- Optionally `nD` (days).
+- If any of hours/minutes/seconds appear, they must be after `T`.
+- `H`, `M`, `S` appear in that order, each optional, each preceded by
+  an integer. Seconds may be fractional.
+- `-` is rejected (the existing code does this; keep that behaviour).
+
+**Implementation steps:**
+
+1. Delete the regex constants (`rStart`, `rDays`, `rTime`, `rHours`,
+   `rMinutes`, `rSeconds`, `rEnd`) and the `xmlDurationRegex` variable
+   at `mpd/duration.go:36-46`. Also remove the `regexp` import.
+2. Replace the body of `ParseDuration` with a single-pass scanner. The
+   scanner walks the string, reading runs of digits (and optional
+   `.` for seconds), then expects the corresponding designator letter.
+   Each designator letter must only appear once, and they must appear
+   in the order `D`, `H`, `M`, `S`.
+
+3. Suggested structure:
+
+   ```go
+   func ParseDuration(str string) (time.Duration, error) {
+       if len(str) < 3 {
+           return 0, newParseDurationError("at least one number and designator are required")
+       }
+       if str[0] != 'P' {
+           return 0, newParseDurationError("duration must be in the format: P[nD][T[nH][nM][nS]]")
+       }
+
+       var (
+           total     time.Duration
+           i         = 1         // cursor, positioned just after 'P'
+           afterT    = false     // have we seen 'T' yet?
+           seenAny   = false     // for the "at least one number" check
+           lastUnit  byte        // tracks order; must strictly increase
+       )
+
+       // Unit ordering, used to enforce "D before H before M before S".
+       rank := func(c byte) int {
+           switch c {
+           case 'D': return 1
+           case 'H': return 2
+           case 'M': return 3
+           case 'S': return 4
+           }
+           return 0
+       }
+
+       for i < len(str) {
+           c := str[i]
+           if c == 'T' {
+               if afterT {
+                   return 0, newParseDurationError("duplicate T in duration")
+               }
+               afterT = true
+               i++
+               continue
+           }
+           if c == '-' {
+               return 0, newParseDurationError("duration cannot be negative")
+           }
+           // Must now read digits (and maybe '.', only if looking for S).
+           start := i
+           sawDot := false
+           for i < len(str) {
+               b := str[i]
+               if b >= '0' && b <= '9' {
+                   i++
+                   continue
+               }
+               if b == '.' && !sawDot {
+                   sawDot = true
+                   i++
+                   continue
+               }
+               break
+           }
+           if i == start {
+               return 0, newParseDurationError("expected digit in duration")
+           }
+           if i == len(str) {
+               return 0, newParseDurationError("number without unit in duration")
+           }
+           unit := str[i]
+           i++
+           if rank(unit) == 0 {
+               return 0, newParseDurationError("unexpected character in duration")
+           }
+           if rank(unit) <= rank(lastUnit) {
+               return 0, newParseDurationError("duration units out of order")
+           }
+           if unit != 'D' && !afterT {
+               return 0, newParseDurationError("H/M/S must follow T")
+           }
+           if sawDot && unit != 'S' {
+               return 0, newParseDurationError("decimal only allowed on S")
+           }
+           lastUnit = unit
+           seenAny = true
+
+           numStr := str[start:i-1] // the slice of digits (and maybe '.') without the unit letter
+
+           switch unit {
+           case 'D':
+               n, err := strconv.ParseUint(numStr, 10, 64)
+               if err != nil {
+                   return 0, newParseDurationError("error parsing Days")
+               }
+               total += time.Duration(n) * 24 * time.Hour
+           case 'H':
+               n, err := strconv.ParseUint(numStr, 10, 64)
+               if err != nil {
+                   return 0, newParseDurationError("error parsing Hours")
+               }
+               total += time.Duration(n) * time.Hour
+           case 'M':
+               n, err := strconv.ParseUint(numStr, 10, 64)
+               if err != nil {
+                   return 0, newParseDurationError("error parsing Minutes")
+               }
+               total += time.Duration(n) * time.Minute
+           case 'S':
+               f, err := strconv.ParseFloat(numStr, 64)
+               if err != nil {
+                   return 0, newParseDurationError("error parsing Seconds")
+               }
+               total += time.Duration(f * float64(time.Second))
+           }
+       }
+       if !seenAny {
+           return 0, newParseDurationError("duration must contain at least one value")
+       }
+       return total, nil
+   }
+   ```
+
+   Notes:
+   - `strconv.ParseUint` / `ParseFloat` accept a `string`, not
+     `[]byte`, but `str[start:i-1]` is a substring of the input; no
+     allocation.
+   - No `strings.TrimRight` calls; we slice the digits out directly.
+   - The error messages match the previous ones as closely as
+     possible — tests may assert against them. If
+     `go test ./...` fails because a test asserts a specific error
+     text, copy the old text.
+
+4. **Unit-test the new parser aggressively.** The existing tests cover
+   the happy path. Add at least:
+
+   - `"PT0S"` → 0
+   - `"P1D"` → 24h
+   - `"PT1H"`, `"PT1M"`, `"PT1S"` → each unit
+   - `"PT0.5S"` → 500ms
+   - `"P1DT2H3M4.5S"` → full combo
+   - Error cases: `""`, `"P"`, `"PT"`, `"P1M"` (M before T),
+     `"PT1.5M"` (decimal not on S), `"P1H"` (H before T), `"P-1D"`,
+     `"P1D2H"` (H before T), `"P1Y"` (unsupported unit), `"P1S1H"`
+     (order), `"P1D1D"` (duplicate).
+
+**Verify:**
+
+```sh
+go test ./mpd -run=Duration      # all duration tests
+go test ./...                    # full suite, especially TestDecodeEncodeMPDs
+benchstat /tmp/dash-mpd-baseline.txt /tmp/dash-mpd-after.txt
+```
+
+Expected: ~2-3 % drop in `BenchmarkUnmarshal` allocs, bigger win on
+MPDs with many `xs:duration` attributes.
+
+---
+
+## 3. Pre-size the `[]Attr` slice in the parser (H2.1)
+
+**Why:** `xml.rawToken` starts each element with `attr = []Attr{}` (a
+zero-length slice with zero capacity) and grows it via `append`. Each
+growth copies the backing array. Profile share of the grow path: ~12 %
+of unmarshal alloc_space.
+
+**File:** `xml/xml.go:796-867` (start-element parsing)
+
+**Steps:**
+
+1. Find line 811: `attr = []Attr{}`
+2. Change to: `attr = make([]Attr, 0, 8)`
+
+   `8` is chosen because most DASH elements have ≤8 attributes.
+   Elements with more will still grow correctly — this only changes
+   the initial capacity.
+
+That's the whole change. One line.
+
+**Verify:**
+
+```sh
+go test ./...
+benchstat ...
+```
+
+Expected: small drop in alloc_objects / alloc_space for Unmarshal.
+Probably 5–10 % allocs.
+
+---
+
+## 4. Pre-size `start.Attr` in the writer (H3.2)
+
+**Why:** Symmetrical to step 3, for marshal. `marshalAttr` appends
+into `start.Attr` one attribute at a time, causing the same grow
+churn.
+
+**File:** `xml/marshal.go` — the function that builds the
+`StartElement` before calling `marshalAttr` for each field. Look at
+`marshalValue` (roughly `xml/marshal.go:400-500`) and `defaultStart`
+(`xml/marshal.go:692` onwards).
+
+**Steps:**
+
+1. Open `xml/typeinfo.go`. Add a method (or inline compute) that
+   returns the count of `fAttr` fields for a given `*typeInfo`:
+
+   ```go
+   func (ti *typeInfo) numAttrFields() int {
+       n := 0
+       for i := range ti.fields {
+           if ti.fields[i].flags&fMode == fAttr {
+               n++
+           }
+       }
+       return n
+   }
+   ```
+
+   Cache it on the `typeInfo` struct so it's computed once per type:
+
+   ```go
+   type typeInfo struct {
+       xmlname  *fieldInfo
+       fields   []fieldInfo
+       nAttrs   int    // NEW: populated at the end of getTypeInfo
+   }
+   ```
+
+   In `getTypeInfo`, after the fields slice is fully built, walk it
+   once and set `tinfo.nAttrs`.
+
+2. In `xml/marshal.go`, find every place `start := StartElement{…}` or
+   `start.Attr = append(start.Attr, startTemplate.Attr...)` runs
+   before the attribute loop. The call site you want is in
+   `marshalValue`, just before the `for i := range tinfo.fields` loop
+   that dispatches `fAttr`. Pre-size:
+
+   ```go
+   if cap(start.Attr) < tinfo.nAttrs {
+       start.Attr = make([]Attr, 0, tinfo.nAttrs)
+   }
+   ```
+
+   Do **not** unconditionally overwrite — `defaultStart` may already
+   have appended template attrs. Grow, don't clobber.
+
+**Verify:**
+
+```sh
+go test ./...
+benchstat ...
+```
+
+Expected: 5–10 % drop in Marshal alloc_objects.
+
+---
+
+## 5. Map-based attribute lookup on `*typeInfo` (H8)
+
+**Why:** In `xml/read.go:458-487` each incoming attribute is matched
+against `tinfo.fields` by linear scan. Types like
+`AdaptationSetType` and `RepresentationType` have ~30 fields. Each
+attribute is therefore O(fields). Profile: ~5 % CPU. This moves up
+in relative cost once we fix the allocation-heavy paths above.
+
+**File:** `xml/typeinfo.go` + `xml/read.go:458-487`
+
+**Steps:**
+
+1. Extend `typeInfo`:
+
+   ```go
+   type typeInfo struct {
+       xmlname *fieldInfo
+       fields  []fieldInfo
+       nAttrs  int                      // (from step 4)
+       attrs   map[attrKey]*fieldInfo   // NEW
+       anyAttr *fieldInfo               // NEW: first fAny|fAttr field, nil if none
+   }
+
+   type attrKey struct {
+       space string
+       local string
+   }
+   ```
+
+2. Populate `attrs` and `anyAttr` at the end of `getTypeInfo`, once the
+   `fields` slice is final (so the `*fieldInfo` pointers we store are
+   stable — **important: store pointers into the final slice, not into
+   an in-progress one**):
+
+   ```go
+   tinfo.attrs = make(map[attrKey]*fieldInfo, tinfo.nAttrs)
+   for i := range tinfo.fields {
+       fi := &tinfo.fields[i]
+       switch fi.flags & fMode {
+       case fAttr:
+           // Some fields apply to any namespace (fi.xmlns == "");
+           // we register them under ("", fi.name). The lookup in
+           // read.go must first try (a.Name.Space, fi.name), then
+           // fall back to ("", fi.name).
+           tinfo.attrs[attrKey{fi.xmlns, fi.name}] = fi
+       case fAny | fAttr:
+           if tinfo.anyAttr == nil {
+               tinfo.anyAttr = fi
+           }
+       }
+   }
+   ```
+
+3. Rewrite the inner loop in `xml/read.go:458-487`:
+
+   ```go
+   for _, a := range start.Attr {
+       fi, ok := tinfo.attrs[attrKey{a.Name.Space, a.Name.Local}]
+       if !ok {
+           // A field registered with empty namespace matches any namespace.
+           fi, ok = tinfo.attrs[attrKey{"", a.Name.Local}]
+       }
+       if ok {
+           strv := fi.value(sv, initNilPointers)
+           if err := d.unmarshalAttr(strv, a); err != nil {
+               return err
+           }
+           continue
+       }
+       if tinfo.anyAttr != nil {
+           strv := tinfo.anyAttr.value(sv, initNilPointers)
+           if err := d.unmarshalAttr(strv, a); err != nil {
+               return err
+           }
+       }
+   }
+   ```
+
+4. **Critical pitfall:** the original code allowed
+   `finfo.xmlns == "" || finfo.xmlns == a.Name.Space` (two cases).
+   Preserve both — the two-step lookup above covers them.
+
+**Verify:** `TestDecodeEncodeMPDs` is the backstop. If any MPD in
+`mpd/testdata/` deserialises differently, the lookup logic is wrong.
+
+Expected: 3–5 % drop in Unmarshal CPU, no allocation change.
+
+---
+
+## 6. Cache `Implements` checks per type (H9)
+
+**Why:** `xml/marshal.go:473-493` asks the reflect system four
+questions per value ("does this implement Marshaler? does its
+pointer? does it implement TextMarshaler? does its pointer?"). These
+are deterministic given the type. Profile: ~7 % of marshal CPU.
+
+**File:** `xml/typeinfo.go` + `xml/marshal.go:473-493`
+
+**Steps:**
+
+1. Extend `typeInfo`:
+
+   ```go
+   type typeInfo struct {
+       // ... existing ...
+       implementsMarshaler        bool
+       implementsAddrMarshaler    bool
+       implementsMarshalerAttr    bool
+       implementsAddrMarshalerAttr bool
+       implementsTextMarshaler    bool
+       implementsAddrTextMarshaler bool
+   }
+   ```
+
+2. Populate at the end of `getTypeInfo`:
+
+   ```go
+   tinfo.implementsMarshaler         = typ.Implements(marshalerType)
+   tinfo.implementsAddrMarshaler     = reflect.PointerTo(typ).Implements(marshalerType)
+   tinfo.implementsMarshalerAttr     = typ.Implements(marshalerAttrType)
+   tinfo.implementsAddrMarshalerAttr = reflect.PointerTo(typ).Implements(marshalerAttrType)
+   tinfo.implementsTextMarshaler     = typ.Implements(textMarshalerType)
+   tinfo.implementsAddrTextMarshaler = reflect.PointerTo(typ).Implements(textMarshalerType)
+   ```
+
+   Note: `getTypeInfo` currently only runs for struct types. You need
+   to ensure these booleans are available for **every** type the
+   marshaller inspects, including non-struct types used as attribute
+   values (e.g. `Duration`). The simplest route is a separate, thinner
+   cache keyed on `reflect.Type`:
+
+   ```go
+   type typeImpl struct {
+       marshaler, addrMarshaler,
+       marshalerAttr, addrMarshalerAttr,
+       textMarshaler, addrTextMarshaler bool
+   }
+   var typeImplMap sync.Map // map[reflect.Type]typeImpl
+
+   func getTypeImpl(t reflect.Type) typeImpl {
+       if v, ok := typeImplMap.Load(t); ok {
+           return v.(typeImpl)
+       }
+       pt := reflect.PointerTo(t)
+       v := typeImpl{
+           marshaler:        t.Implements(marshalerType),
+           addrMarshaler:    pt.Implements(marshalerType),
+           marshalerAttr:    t.Implements(marshalerAttrType),
+           addrMarshalerAttr: pt.Implements(marshalerAttrType),
+           textMarshaler:    t.Implements(textMarshalerType),
+           addrTextMarshaler: pt.Implements(textMarshalerType),
+       }
+       typeImplMap.Store(t, v)
+       return v
+   }
+   ```
+
+3. In `marshalValue` (around `xml/marshal.go:473-493`) and
+   `marshalAttr` (around `xml/marshal.go:608-652`), replace
+   `val.Type().Implements(marshalerType)` with
+   `getTypeImpl(val.Type()).marshaler`, and similarly for the other
+   three checks. The `val.CanInterface()` / `val.CanAddr()` guards
+   stay as they are — those are fast and depend on runtime state, not
+   type identity.
+
+**Verify:**
+
+```sh
+go test ./...
+benchstat ...
+```
+
+Expected: 3–5 % drop in Marshal CPU, no allocation change.
+
+---
+
+## 7. Bypass `Attr` construction for simple attributes (H3.1 + H3.3)
+
+**Why:** `marshalAttr` materialises a whole `Attr{name, string}` and
+appends it to `start.Attr` even for plain numeric fields. For the
+numeric branch it also calls `strconv.FormatInt/FormatUint/
+FormatFloat`, each of which allocates a Go string. Together this is
+~75 % of marshal allocations.
+
+**This step is the single biggest marshal win, and also the most
+invasive.** Do it after steps 3–6 so you're landing it on a stable
+base.
+
+**File:** `xml/marshal.go` (`marshalAttr` at lines 606-688,
+`marshalSimple` at lines 883-916, `writeStart` at lines 746-846)
+
+**Steps:**
+
+1. Read `writeStart` end-to-end. Understand how it currently iterates
+   `start.Attr` and writes each as `name="value"` to the buffered
+   writer. The goal of this step is to let `marshalAttr` write
+   directly to that buffer for numeric/string attributes, while still
+   falling back to the `start.Attr` list for custom
+   `MarshalerAttr`/`TextMarshaler` paths.
+
+2. Split `marshalValue`'s attribute loop into two passes:
+
+   - **Pass A** (existing): iterate fields, but for each attribute
+     decide whether it has a custom marshaller. If it does, call it
+     and append the returned `Attr` to `start.Attr`. If it does *not*,
+     skip — we'll handle it in Pass B.
+   - In between, call `writeStart(start)` once, which writes the
+     element opening plus the accumulated `start.Attr` (custom ones
+     only).
+   - **Pass B** (new): iterate fields again, this time for every
+     "simple" attribute, write `name="value"` directly to
+     `p.Writer` using a new helper:
+
+     ```go
+     func (p *printer) writeSimpleAttr(prefix, local string, val reflect.Value) error {
+         p.Writer.WriteByte(' ')
+         if prefix != "" {
+             p.WriteString(prefix)
+             p.WriteByte(':')
+         }
+         p.WriteString(local)
+         p.WriteString(`="`)
+         if err := p.writeSimpleAttrValue(val); err != nil {
+             return err
+         }
+         p.WriteByte('"')
+         return nil
+     }
+     ```
+
+   The element's `>` must be written after both passes complete.
+
+3. Implement `writeSimpleAttrValue`. This is essentially a copy of
+   `marshalSimple` but it writes directly to the buffered writer
+   instead of returning `(string, []byte, error)`. For integers and
+   floats, use the `strconv.AppendInt` / `AppendUint` /
+   `AppendFloat` / `AppendBool` family with a stack-local scratch
+   buffer:
+
+   ```go
+   var scratch [64]byte
+   switch val.Kind() {
+   case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+       b := strconv.AppendInt(scratch[:0], val.Int(), 10)
+       _, err := p.Writer.Write(b)
+       return err
+   case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+       b := strconv.AppendUint(scratch[:0], val.Uint(), 10)
+       _, err := p.Writer.Write(b)
+       return err
+   case reflect.Float32, reflect.Float64:
+       b := strconv.AppendFloat(scratch[:0], val.Float(), 'g', -1, val.Type().Bits())
+       _, err := p.Writer.Write(b)
+       return err
+   case reflect.Bool:
+       b := strconv.AppendBool(scratch[:0], val.Bool())
+       _, err := p.Writer.Write(b)
+       return err
+   case reflect.String:
+       return EscapeText(p.Writer, []byte(val.String()))
+       // or a direct string-escape helper if one exists
+   // ... other kinds as needed ...
+   }
+   ```
+
+   `EscapeText` already exists in the package for XML-escaping.
+
+4. **XML escaping for attribute values:** the current code runs string
+   attribute values through `EscapeText` or its equivalent before
+   writing. Do **not** skip this — an attribute containing `<`, `&`,
+   `"` etc. must be escaped. Re-use the existing escape routine.
+
+5. Keep the old `start.Attr`-based path alive for:
+   - Any type implementing `MarshalerAttr` (e.g. `mpd.Duration`).
+   - Any type implementing `encoding.TextMarshaler`.
+   - Fields tagged `,any,attr`.
+
+   These emit attributes through their custom method, and the result
+   can't be written directly without the `Attr` intermediate (the
+   method returns one). Use the `typeImpl` cache from step 6 to decide
+   cheaply.
+
+6. **This change requires a thorough round-trip test run.** Run
+   `TestDecodeEncodeMPDs` (which parses every `.mpd` under
+   `mpd/testdata/` and checks semantic equality after re-encoding)
+   after each sub-change. If output byte-order for attributes changes
+   (we now emit them in two passes), `xmltree.Equal` still treats the
+   XML as equal — attribute ordering is not semantically significant.
+
+**Verify:**
+
+```sh
+go test ./...
+benchstat ...
+```
+
+Expected: ~50 % drop in Marshal alloc_objects and ~50 % in ns/op.
+
+**If anything breaks:** revert and land it as a smaller series of
+changes, e.g. first just move numeric attrs to the new path, then
+strings, then booleans.
+
+---
+
+## 8. Intern attribute / element names on the Decoder (H2.2)
+
+**Why:** In any given MPD, the strings `"Period"`, `"AdaptationSet"`,
+`"Representation"`, `"id"`, `"bandwidth"`, `"mimeType"`, etc. appear
+hundreds or thousands of times. Each appearance currently allocates a
+fresh Go string via `string(d.buf.Bytes())` in `Decoder.nsname` and
+related helpers. A per-Decoder intern map collapses those into one
+allocation per unique name.
+
+**File:** `xml/xml.go` (`Decoder` struct, `nsname`, `name`, and the
+places where `string(d.buf.Bytes())` appears)
+
+**Steps:**
+
+1. Add a field to `Decoder`:
+
+   ```go
+   nameIntern map[string]string
+   ```
+
+   Initialise lazily (first use creates it). Reset it in
+   `Decoder.Reset()` if such a function exists, or add a comment that
+   the intern map lives for the Decoder's lifetime.
+
+2. Add a helper:
+
+   ```go
+   func (d *Decoder) internBytes(b []byte) string {
+       if d.nameIntern == nil {
+           d.nameIntern = make(map[string]string, 128)
+       }
+       if s, ok := d.nameIntern[string(b)]; ok { // map lookup with []byte key — Go special-case, no alloc
+           return s
+       }
+       s := string(b)
+       d.nameIntern[s] = s
+       return s
+   }
+   ```
+
+   The `d.nameIntern[string(b)]` form is specifically optimised by the
+   Go compiler since 1.5: the `string(b)` conversion in a map key
+   doesn't actually allocate. Look it up to confirm for the Go version
+   in use.
+
+3. Replace every occurrence of `string(d.buf.Bytes())` that is
+   returning a **name** (tag name, attribute name, namespace prefix
+   alias) with `d.internBytes(d.buf.Bytes())`. Do **not** intern
+   attribute *values* or character data — those have unbounded
+   cardinality and would leak.
+
+   Specifically look at:
+   - `d.nsname()` → name comes from `d.buf.Bytes()`.
+   - `d.name()` → same.
+   - The namespace URI → technically also bounded in an MPD; can be
+     interned.
+
+4. **Bound the intern map.** Because this is per-Decoder and a
+   Decoder is normally short-lived (one `Unmarshal` call), unbounded
+   growth is not a concern. If a caller holds onto a Decoder and feeds
+   it a stream of unrelated documents, the map grows. Add a simple
+   cap:
+
+   ```go
+   const maxInternEntries = 1024
+   ...
+   if len(d.nameIntern) < maxInternEntries {
+       d.nameIntern[s] = s
+   }
+   return s
+   ```
+
+   If over the cap, return the fresh string without storing — graceful
+   degradation.
+
+**Verify:**
+
+```sh
+go test ./...
+benchstat ...
+```
+
+Expected: 10–15 % drop in Unmarshal alloc_objects on any real MPD (the
+savings scale with element/attribute repetition).
+
+---
+
+## 9. Pool and reuse `xml.Encoder` instances (H5)
+
+**Why:** `xml.NewEncoder` calls `bufio.NewWriter` which allocates a
+4 KiB buffer every call. For a service marshaling many MPDs per
+second that's 4 KiB of garbage per call. Profile: ~2 % of Marshal
+allocs *per call* — bigger in absolute terms when you do many.
+
+**File:** `xml/marshal.go:141-145`, plus a new pool helper
+
+**Steps:**
+
+1. Add a `sync.Pool` of `*Encoder` at package scope. Pool elements
+   should have their `bufio.Writer` reset to a scratch
+   `*bytes.Buffer` on release, then re-targeted at the caller's
+   `io.Writer` on acquire:
+
+   ```go
+   var encoderPool = sync.Pool{
+       New: func() any {
+           return &Encoder{printer{Writer: bufio.NewWriter(io.Discard)}}
+       },
+   }
+   ```
+
+2. Expose a new API: `AcquireEncoder(io.Writer) *Encoder` and
+   `ReleaseEncoder(*Encoder)`. The acquirer calls
+   `enc.Writer.Reset(w)` before returning the encoder; the releaser
+   resets internal state (`elements`, `depth`, `prefix`, `putNewline`,
+   any maps) to zero and puts the encoder back. Do **not** expose the
+   pool — only the acquire/release pair — so callers can't accidentally
+   use an encoder twice.
+
+3. **Do not change `NewEncoder`'s signature or semantics.** Keep it
+   allocating a fresh one; there are callers outside this repo.
+
+4. In `mpd/io.go`, update `Write` / `WriteToString` to use the pooled
+   path. See step 10 for the recommended shape, since these two
+   changes combine naturally.
+
+**Verify:**
+
+```sh
+go test ./...
+benchstat ...
+```
+
+Expected: noticeable drop in Marshal allocs/op (the 4 KiB buffer is
+the single largest allocation per Marshal call).
+
+---
+
+## 10. Stream `mpd.(*MPD).Write` directly, no intermediate buffer (H6)
+
+**Why:** `Write` currently calls `xml.MarshalIndent` which returns a
+`[]byte`, then copies that `[]byte` to the caller's `io.Writer`.
+`WriteToString` adds a third copy. For a 500 KB live MPD we hold a
+500 KB buffer we don't need.
+
+**File:** `mpd/io.go:42-71`
+
+**Steps:**
+
+1. Rewrite `Write` to stream:
+
+   ```go
+   func (m *MPD) Write(w io.Writer, indent string, withHeader bool) (int, error) {
+       cw := &countingWriter{w: w}
+       if withHeader {
+           if _, err := io.WriteString(cw, xml.Header); err != nil {
+               return cw.n, err
+           }
+       }
+       enc := xml.AcquireEncoder(cw)
+       defer xml.ReleaseEncoder(enc)
+       enc.Indent("", indent)
+       if err := enc.Encode(m); err != nil {
+           return cw.n, err
+       }
+       if err := enc.Flush(); err != nil {   // make sure bufio flushes into cw
+           return cw.n, err
+       }
+       return cw.n, nil
+   }
+   ```
+
+   Add a small `countingWriter` (wraps an `io.Writer` and counts bytes
+   written) in the same file.
+
+2. Rewrite `WriteToString` to use the streaming path:
+
+   ```go
+   func (m *MPD) WriteToString(indent string, withHeader bool) (string, error) {
+       var buf bytes.Buffer
+       buf.Grow(4096)
+       if _, err := m.Write(&buf, indent, withHeader); err != nil {
+           return "", err
+       }
+       return buf.String(), nil
+   }
+   ```
+
+   Even better: use `strings.Builder` — `buf.String()` on
+   `bytes.Buffer` copies, `strings.Builder.String()` does not. Check
+   whether `strings.Builder` satisfies the `io.Writer` requirements
+   used by `Write` (it does).
+
+3. Make sure the test `TestDecodeEncodeMPDs` still passes — it calls
+   `xml.MarshalIndent` directly, not `Write`, so it's unaffected. But
+   add a new test that explicitly round-trips via `Write` /
+   `ReadFromBytes` on a big testdata MPD.
+
+**Verify:**
+
+```sh
+go test ./...
+```
+
+For a big-MPD benchmark, see step 12.
+
+---
+
+## 11. Tidy `Duration.String` concatenation (H4)
+
+**Why:** `mpd/duration.go:69-137` returns
+`"PT" + string(buf[w:])`. The `+` creates an extra string. This is
+only ~3.7 % of marshal allocs but trivial to fix.
+
+**File:** `mpd/duration.go:69-137`
+
+**Steps:**
+
+1. Pre-seed `'P'` and `'T'` at the very beginning of `buf`, or leave
+   two bytes of head-room in `buf` so the final `w--` can write them.
+   Easiest: at the very end, instead of `return "PT" + string(buf[w:])`,
+   do:
+
+   ```go
+   w--
+   buf[w] = 'T'
+   w--
+   buf[w] = 'P'
+   return string(buf[w:])
+   ```
+
+   Check that the 32-byte buffer still has room. The max output is
+   `PT2540400H10M10.000S` = 20 chars; we have plenty.
+
+2. Handle the negative case: `-` goes before `P`, so move the
+   `if neg { buf[w] = '-' }` after the `P`/`T` prefix:
+
+   ```go
+   w--
+   buf[w] = 'T'
+   w--
+   buf[w] = 'P'
+   if neg {
+       w--
+       buf[w] = '-'
+   }
+   return string(buf[w:])
+   ```
+
+**Verify:** This function has direct unit tests in the `mpd` package.
+Run them:
+
+```sh
+go test ./mpd -run=Duration
+```
+
+Expected: 1 fewer allocation per Marshal of a `Duration` attribute
+(small absolute win, but it's a one-liner).
+
+---
+
+## 12. Fill benchmark coverage gaps
+
+**Why:** The existing benchmarks only exercise a 60-line MPD. Real
+hot paths (large live manifests with long `SegmentTimeline`s, on-demand
+ladders, multi-period content) behave very differently and are not
+currently measured. Without these, regressions on real workloads will
+slip through.
+
+**File:** `mpd/mpd_test.go`
+
+**Steps:**
+
+1. Add a parametrised benchmark that iterates a representative subset
+   of `mpd/testdata/`. Pattern:
+
+   ```go
+   func BenchmarkUnmarshalCorpus(b *testing.B) {
+       files, err := filepath.Glob("testdata/schema-mpds/*.mpd")
+       require.NoError(b, err)
+       for _, f := range files {
+           data, err := os.ReadFile(f)
+           require.NoError(b, err)
+           b.Run(filepath.Base(f), func(b *testing.B) {
+               b.ReportAllocs()
+               for i := 0; i < b.N; i++ {
+                   mpd := m.MPD{}
+                   _ = xml.Unmarshal(data, &mpd)
+               }
+           })
+       }
+   }
+   ```
+
+   Mirror this for `BenchmarkMarshalCorpus`.
+
+2. Add a `BenchmarkWriteToDiscard` that uses `(*MPD).Write` into
+   `io.Discard` to validate the streaming path from step 10:
+
+   ```go
+   func BenchmarkWriteToDiscard(b *testing.B) {
+       mpd, err := m.ReadFromFile("testdata/schema-mpds/example_G15.mpd")
+       require.NoError(b, err)
+       b.ReportAllocs()
+       for i := 0; i < b.N; i++ {
+           _, _ = mpd.Write(io.Discard, "  ", true)
+       }
+   }
+   ```
+
+3. **Add a large-MPD fixture** if one is not already present. Look
+   through `mpd/testdata/livesim/` for a long-`SegmentTimeline`
+   example. If none is big enough, synthesise one with many `<S>`
+   children (a few hundred) and check it in as
+   `testdata/other/long-timeline.mpd`. Add an unmarshal and marshal
+   benchmark specifically for it — that's where most real-world cost
+   lives.
+
+**Verify:** `go test ./mpd -bench=. -benchmem` runs all benchmarks
+cleanly, including the new ones.
+
+---
+
+## 13. (Optional, low priority) `mpd.ReadFromReader` for `io.Reader` sources (H7)
+
+**Why:** Today a caller with an `io.Reader` (HTTP body, stdin) must
+`io.ReadAll` before calling `MPDFromBytes`. A streaming API avoids
+the intermediate buffer.
+
+**File:** `mpd/io.go`
+
+**Steps:**
+
+1. Add:
+
+   ```go
+   func ReadFromReader(r io.Reader) (*MPD, error) {
+       br := bufio.NewReader(r)
+       mpd := MPD{}
+       if err := xml.NewDecoder(br).Decode(&mpd); err != nil {
+           return nil, err
+       }
+       mpd.SetParents()
+       return &mpd, nil
+   }
+   ```
+
+2. Leave `ReadFromFile` as it is — `os.ReadFile` into `Unmarshal` is
+   already fine for local files and avoids double-buffering through
+   bufio.
+
+**Verify:** add a unit test that calls `ReadFromReader` on a
+`bytes.Reader` wrapping a testdata MPD, and checks it round-trips to
+the same output as `ReadFromFile`.
+
+---
+
+## 14. (Optional, defer) H11 — per-byte reader
+
+Skip. The report's recommendation is "leave alone until H1–H4 are
+done, then re-profile". After landing steps 2–8 you should re-run
+`go test -cpuprofile` and see whether `getc` still shows up. If it
+does and Unmarshal is still a concern, revisit.
+
+---
+
+## Expected cumulative effect
+
+Measured from baseline to end of step 11:
+
+| Benchmark          | Baseline       | Target          | How we get there        |
+|--------------------|----------------|-----------------|-------------------------|
+| BenchmarkUnmarshal | ~57 µs, 703 allocs | ~40 µs, ~350 allocs | Steps 2, 3, 5, 8         |
+| BenchmarkMarshal   | ~26 µs, 108 allocs | ~15 µs, ~30 allocs  | Steps 4, 6, 7, 9, 10, 11 |
+
+These are estimates from the profile shares in the audit report. The
+actual numbers per step must be **measured**, not assumed — if a step
+doesn't produce the expected improvement, stop and investigate before
+layering more changes on top.
+
+## Correctness invariants you must preserve
+
+- **Round-trip equality:** `TestDecodeEncodeMPDs` (`mpd/mpd_test.go:22`)
+  parses every file under `mpd/testdata/` and re-serialises it,
+  verifying semantic equality via `aqwari.net/xml/xmltree`. Run this
+  after every single step. If it fails, stop and debug before moving on.
+- **Public API:** do not change any exported function's signature in
+  the `mpd` package without a deprecation cycle. The `xml` package is
+  a fork used internally — it's safer to change, but still, don't
+  remove exported names.
+- **No behaviour changes on invalid input:** `ParseDuration` must
+  still return an error on every malformed input that it currently
+  rejects. Add explicit test cases for each class of malformed input
+  before rewriting (step 2).
+- **Concurrency:** `sync.Pool` (step 9) and `sync.Map` (steps 5, 6)
+  are both safe for concurrent use. The per-`Decoder` intern map
+  (step 8) is **not** shared across decoders, so no locking needed.
+  Don't be tempted to share it globally — it would need a mutex and
+  would grow unboundedly.
+
+## Things explicitly out of scope
+
+- Redesigning the schema structs to avoid pointer-valued optional
+  fields (`*bool`, `*uint32`, …). That would eliminate a large
+  fraction of the remaining `reflect.unsafe_New` allocations but is a
+  breaking API change and a much larger project.
+- Generating `MarshalXML` / `UnmarshalXML` methods per type. Also a
+  big change; revisit only if the reflection-based hot path is still
+  dominant after all of the above.
+- Replacing `go-deepcopy` in `Clone`. Out of scope for the read/write
+  focus (cloning isn't used by parse or write paths).

--- a/discovery/performance_report.md
+++ b/discovery/performance_report.md
@@ -1,0 +1,473 @@
+# Performance Audit: dash-mpd
+
+Focus: reading (`xml.Unmarshal` / `mpd.ReadFromFile`) and writing
+(`xml.MarshalIndent` / `mpd.(*MPD).Write`) of DASH MPDs.
+
+Audit environment:
+- macOS (darwin/arm64), Apple M4 Pro, Go 1.26.0
+- Commit at audit: `a1042ec` (v0.14.1), clean tree
+- Sample corpus: `mpd/testdata/schema-mpds/example_G15.mpd` (~60 lines,
+  single period, DRM signalling and segment template). Representative of a
+  small static MPD, not of large live MPDs with long SegmentTimelines.
+
+---
+
+## 1. Baseline numbers
+
+Existing benchmarks (`mpd/mpd_test.go`), `go test -bench=. -benchmem -benchtime=5s`:
+
+| Benchmark          | ns/op   | B/op   | allocs/op |
+|--------------------|---------|--------|-----------|
+| BenchmarkUnmarshal | ~57 600 | 37 080 | **703**   |
+| BenchmarkMarshal   | ~26 500 | 19 320 | **108**   |
+
+`BenchmarkClone` fails (stack overflow / `go-cmp` infinite recursion
+following the `parent *MPD` back-pointer). That is a bug in the benchmark
+set-up, covered in §5.
+
+On a 60-line MPD we allocate **703 objects per parse and 108 per write**.
+Every allocation costs both bytes and GC pressure; CPU profiles below
+confirm that GC/scheduler overhead (`runtime.kevent`, `madvise`,
+`pthread_cond_*`) dominates wall time for both operations.
+
+### CPU/alloc profile highlights
+
+Profiles were collected via `-cpuprofile` / `-memprofile` with
+`-benchtime=5s`.
+
+#### Unmarshal — `alloc_space`
+
+```
+  flat   flat%                                              cum%
+38.79%  (*Decoder).rawToken           // Attr slice + string(data) copies
+27.69%  reflect.unsafe_New            // *Period, *AdaptationSet, *string, *uint64 …
+ 8.56%  (*Decoder).Token
+ 3.84%  (*Decoder).name               // string(d.buf.Bytes())
+ 3.09%  (*Decoder).unmarshalAttr
+ 2.16%  copyValue                     // string(src) for chardata
+ 3.38%  mpd.ParseDuration / Duration.UnmarshalXMLAttr
+ 2.44%  regexp.(*Regexp).backtrack
+```
+
+#### Unmarshal — `cpu` (non-runtime only)
+
+```
+ 4.42%  (*Decoder).getc               // byte-at-a-time read
+ 5.36%  (*fieldInfo).value + reflect.Value.Field
+ 4.73%  (*Decoder).text
+ 3.79%  runtime.mallocgcSmallScanNoHeader
+ 3.94%  isName  (unicode.Is on every read name)
+```
+
+Runtime counters (`kevent`, `madvise`, `pthread_cond_*`) together account
+for >60 % of samples — symptom of the allocation volume above, not of
+syscalls.
+
+#### Marshal — `alloc_objects`
+
+```
+75.92%  (*printer).marshalAttr        // append(start.Attr, Attr{name, s})
+ 4.31%  strconv.FormatUint
+ 3.86%  (*printer).writeStart         // nsToPrefix / prefixToNS maps
+ 3.71%  mpd.(*Duration).String        // "PT" + string(buf[w:])
+ 3.59%  (*printer).createPrefix
+ 2.04%  bufio.NewWriterSize           // new 4 KiB buffer per Encode
+ 1.48%  xml.joinPrefixed              // prefix + ":" + name
+ 1.04%  strconv.FormatInt
+```
+
+Marshal CPU, like unmarshal, shows the reflect-based type resolution
+(`reflect.implements`, `(*rtype).Implements`, `reflect.Value.Field`,
+`(*fieldInfo).value`) as the dominant non-GC cost.
+
+---
+
+## 2. Architectural constraints that bound what we can do
+
+1. **Patched `encoding/xml`.** The `xml/` package is a fork of Go's
+   standard library with namespace-prefix support bolted on
+   (`README.md:46-64`). Every optimisation lives in our tree, so it is
+   available to us — but it also has to keep producing byte-identical
+   output vs. the existing test corpus.
+2. **Schema-generated struct tree with many pointer fields.** `mpd/mpd.go`
+   has 71 struct types and 439 `xml:"…"` tags. Optional scalars are
+   modelled as pointers (`*bool`, `*uint32`, `*Duration`, `*string`) to
+   distinguish "absent" from "zero". Every populated optional scalar is
+   therefore one heap allocation. Slices such as
+   `Periods []*Period` are slices of pointers. This is unavoidable
+   without a wider schema redesign, and it explains the 27.7 % share of
+   `reflect.unsafe_New` in alloc_space.
+3. **Linear attribute matching.** `README.md:90-95` already notes this.
+   `xml.unmarshal` walks `tinfo.fields` linearly for every incoming
+   attribute (`xml/read.go:458-487`). With ~30-field types like
+   `AdaptationSetType` and `RepresentationType`, each attribute does a
+   linear scan.
+
+---
+
+## 3. Findings, ranked by expected impact
+
+### H1 — `mpd.ParseDuration` runs the same regex twice *(high impact, low risk)*
+
+**Location:** `mpd/duration.go:181-231`
+
+```go
+if !xmlDurationRegex.Match([]byte(str)) { … }         // first scan, + []byte alloc
+var parts = xmlDurationRegex.FindStringSubmatch(str)   // second scan + allocs
+```
+
+- Two full regex traversals per duration.
+- `[]byte(str)` is a wasted copy.
+- Every call allocates `parts` (a `[]string` of 5 elements) plus an
+  internal `bitState` (profile shows 1.52 % of all alloc_space in
+  `regexp.(*bitState).reset`).
+- Then `strings.TrimRight` + `strconv.Atoi` allocates per segment.
+
+Impact on the MPD corpus: `ParseDuration` alone accounts for **3.4 %** of
+alloc_space and 1.8 % of alloc_objects on a single-period small MPD; on
+live MPDs with many `SegmentTimeline S@d` or `Event@duration` attributes
+the proportion scales roughly with period/segment count. Segments are
+usually typed as raw `uint64` though, so the biggest wins come from MPDs
+with many `availabilityTimeOffset`, `minBufferTime`, etc.
+
+**Recommendation:** drop regex. Hand-write a scanner for the
+`P[nD][T[nH][nM][nS]]` grammar — one pass, no heap traffic in the happy
+path. Fallback to an explicit error message on malformed input.
+Estimated: >10× speed-up on `ParseDuration`, eliminates all of its
+allocations, shrinks unmarshal allocs by ~2-3 %.
+
+### H2 — `xml.rawToken` allocates a fresh `Attr` slice and string per attribute *(high impact)*
+
+**Location:** `xml/xml.go:796-867`
+
+```go
+attr = []Attr{}
+for { …
+    a.Name, _ = d.nsname()      // string(d.buf.Bytes()) per name
+    a.Value  = string(data)     // string copy out of d.buf
+    attr = append(attr, a)      // slice grow
+}
+return StartElement{name, attr}, nil
+```
+
+Per-attribute cost: up to **three allocations** (name string, value
+string, slice extension). Profile: 38.8 % of unmarshal alloc_space sits
+in `rawToken`, split roughly:
+
+- 12.1 % — `attr = append(attr, a)` (slice backing array reallocations)
+- 6.8 % — `a.Value = string(data)`
+- 6.8 % — `a.Name = d.nsname()`
+- 4.3 % — `return StartElement{name, attr}`
+
+**Recommendations** (ordered by effort):
+
+1. Pre-size the slice: `attr = make([]Attr, 0, 8)` avoids most of the
+   growth allocations for the typical ≤8 attributes/element in DASH.
+   One-liner, measurable win.
+2. Intern XML names. In an MPD the same ~60 tag names (`Period`,
+   `AdaptationSet`, `Representation`, `SegmentTemplate`, …) and the same
+   ~100 attribute names (`id`, `bandwidth`, `mimeType`, `codecs`,
+   `timescale`, …) appear thousands of times. Keep a per-`Decoder`
+   `map[string]string` that turns the `d.buf.Bytes()` slice into a
+   canonical `string` on first occurrence and returns the interned one
+   thereafter. Costs one map lookup per name, saves the `string(b)`
+   allocation for every repeat. The canonicaliser needs to be on the
+   Decoder (not global) to avoid unbounded growth across long-running
+   services.
+3. Pool `[]Attr` and `StartElement` backing storage. The token returned
+   by `rawToken` is consumed almost immediately by
+   `Decoder.Token`/`unmarshal`. A scoped `sync.Pool` for the Attr slice
+   is feasible but invasive — the Attr slice currently outlives the
+   call. Defer this until (1) and (2) have been measured.
+
+### H3 — `xml.marshalAttr` allocates an `Attr` and a number string per attribute *(high impact)*
+
+**Location:** `xml/marshal.go:607-688`, `marshalSimple` at lines 883-916.
+
+Each struct attribute does:
+
+1. Recurse into `marshalSimple`, which calls
+   `strconv.FormatInt/FormatUint/FormatFloat/FormatBool` returning a
+   *string* (`strconv.FormatUint = 4.31 %` of marshal allocs).
+2. Build `Attr{name, s}` and `append` it onto `start.Attr`.
+
+75.92 % of marshal allocations come from this path. Two complementary
+fixes:
+
+1. **Skip the Attr struct entirely for simple fields.** `writeStart`
+   (`xml/marshal.go:746-846`) is the only consumer of `start.Attr`, and
+   it only reads each Attr once. Instead of materialising a `[]Attr`
+   then iterating it, `marshalValue` could call a `writeAttr(prefix,
+   name, value)` method that writes directly into the `bufio.Writer`
+   after `writeStart` has emitted the element's prefix logic. Trade-off:
+   custom `MarshalXMLAttr` implementations (e.g.
+   `mpd/duration.go:48-53`) return an `Attr`, so we still need the
+   intermediate representation for those paths — but numeric/string
+   attributes are the vast majority.
+2. **Pre-size the attr slice** analogously to H2: `start.Attr =
+   make([]Attr, 0, N)` where N is the struct's attribute count from
+   `tinfo`. Cheap, reduces growslice churn until (1) lands.
+3. **Append ints directly.** `marshalSimple` already uses
+   `strconv.AppendInt` in the `fCharData` branch (lines 984-999). The
+   attribute branch should do the same with a scratch `[64]byte` and
+   return `[]byte` so we never materialise a Go string for transient
+   numeric values.
+
+### H4 — `mpd.(*Duration).String` allocates the final string via concatenation *(medium)*
+
+**Location:** `mpd/duration.go:69-137`
+
+```go
+return "PT" + string(buf[w:])
+```
+
+3.71 % of marshal allocations. The `buf` has 32 bytes and the scratch
+already lives on the stack — we only pay to turn it into a `string`.
+
+**Recommendation:** pre-write `'P','T'` into `buf` when constructing the
+output so the function returns `string(buf[w:])` with no concatenation,
+and then have `Duration.MarshalXMLAttr` return an attribute whose value
+shares a pooled buffer where possible. A simpler intermediate step: keep
+the prefix in `buf` and remove the `+` operator (saves one allocation
+per call).
+
+### H5 — `xml.Encoder` allocates a 4 KiB `bufio.Writer` per call *(medium)*
+
+**Location:** `xml/marshal.go:141-145`
+
+```go
+func NewEncoder(w io.Writer) *Encoder {
+    e := &Encoder{printer{Writer: bufio.NewWriter(w)}}
+    …
+}
+```
+
+`bufio.NewWriterSize` accounts for 2.04 % of marshal allocs per call. On
+`mpd.(*MPD).WriteToString`/`Write` this is per-invocation overhead. For
+services that write many MPDs per second (live origin / packager) this
+adds up.
+
+**Recommendations:**
+
+1. Expose a `sync.Pool` of `*Encoder` and reuse them between calls. The
+   `printer` struct holds transient state (`elements`, `depth`,
+   `putNewline`) that `Encode` leaves behind at zero values, so a
+   simple reset before returning to the pool is enough.
+2. Alternatively, if the caller already supplies a buffer
+   (`mpd.(*MPD).Write` writes to a `bytes.Buffer`/`http.ResponseWriter`
+   that is itself buffered), expose an API that bypasses the internal
+   bufio — `NewEncoderUnbuffered(io.Writer)`.
+
+### H6 — Double buffering between `Marshal` and the caller *(medium)*
+
+**Location:** `mpd/io.go:43-71`
+
+```go
+func (m *MPD) Write(w io.Writer, indent string, withHeader bool) (int, error) {
+    data, err := xml.MarshalIndent(m, "", indent)           // full copy in memory
+    …
+    n, err = w.Write(data)                                  // then copy to w
+}
+```
+
+`MarshalIndent` returns a `[]byte` that is copied out. For large live
+MPDs (multi-period, long timelines, tens to hundreds of KB) this doubles
+peak memory and adds a `memmove`. `WriteToString` adds a *third* copy
+(`string(data)`).
+
+**Recommendation:** stream via `xml.NewEncoder(w)` + `enc.Indent(…)` +
+`enc.Encode(m)`. Signature of `Write` stays the same; remove the
+intermediate `[]byte`. Combine with H5's pool for a bounded-memory fast
+path.
+
+### H7 — `ReadFromFile` buffers the whole file, then re-reads via `bytes.Reader` *(low-medium)*
+
+**Location:** `mpd/io.go:11-24`
+
+```go
+data, err := os.ReadFile(path)
+…
+err = xml.Unmarshal(data, &mpd)   // bytes.NewReader internally
+```
+
+Two alternatives:
+
+- Keep as is — for local file I/O this is rarely the bottleneck and the
+  `bytes.Reader` path is already zero-copy.
+- Switch to `xml.NewDecoder(bufio.NewReader(f)).Decode(&mpd)` for
+  `io.Reader` sources (HTTP body, stdin). This is the more important
+  case: today a caller who has an `io.Reader` must `io.ReadAll` first.
+
+**Recommendation:** add `mpd.ReadFromReader(io.Reader) (*MPD, error)`
+that streams through a bufio reader. Leaves `ReadFromFile` semantics
+alone.
+
+### H8 — Reflection-driven attribute lookup is O(fields × attrs) per element *(medium, already known)*
+
+**Location:** `xml/read.go:458-487`
+
+```go
+for _, a := range start.Attr {
+    …
+    for i := range tinfo.fields {
+        finfo := &tinfo.fields[i]
+        switch finfo.flags & fMode {
+        case fAttr:
+            if a.Name.Local == finfo.name && … {
+```
+
+The `README` already calls this out. In CPU profiles today it sits at
+~5.4 % (`(*fieldInfo).value` + `reflect.Value.Field`), eclipsed by
+allocation pressure — so attacking H1-H3 first will shift this up in
+relative cost.
+
+**Recommendation:** extend the cached `*typeInfo` with an
+`attrs map[string]*fieldInfo` (and, if needed, an `attrsByNS` map). The
+existing `tinfoMap sync.Map` already memoises per-type info, so we only
+pay map construction once per type. Swap the inner loop for a single
+lookup.
+
+Side benefit: removes the need for the `any`-attr scan rewriting in
+`read.go:472-486`. Keep a small parallel list of `fAny|fAttr` fields.
+
+### H9 — `reflect.implements` checks done 4× per marshalled value *(low-medium)*
+
+**Location:** `xml/marshal.go:473-493`
+
+Each value asks: does `typ` implement `Marshaler`? If not, does `*typ`?
+Then the same pair for `TextMarshaler`. Profile shows
+`reflect.implements` + `(*rtype).Implements` ≈ 7 % of marshal CPU.
+
+**Recommendation:** cache per-type booleans
+(`implementsMarshaler`, `implementsAddrMarshaler`, … ) on the
+`*typeInfo`. That pushes the lookup into the `sync.Map` we already have
+and replaces four `Implements` calls with four bool loads.
+
+### H10 — `BenchmarkClone` is broken *(blocker for cloning work)*
+
+**Location:** `mpd/mpd_test.go:118-129`
+
+```go
+cmp.Equal(&mpd, mpdCopy)       // not what you want
+for i := 0; i < b.N; i++ {
+    _ = m.Clone(&mpd)
+}
+```
+
+`go-cmp` traverses the struct and follows the `parent` back-pointer that
+`SetParents()` sets on `Period`/`AdaptationSetType`/… creating an
+infinite recursion; it stack-overflows on entry. This is what makes
+`go test -bench=.` abort rather than reporting Clone numbers.
+
+Regardless of the bench fix, `Clone` uses
+`github.com/barkimedes/go-deepcopy` (`mpd/mpd.go:101-105`,
+`mpd/period.go:178-182`), a reflection-based deep copier that is ~10×
+slower than a generated or marshal-roundtrip clone for similar trees.
+
+**Recommendations:**
+
+1. Fix the benchmark: remove the errant `cmp.Equal` call (it does
+   nothing useful there) and move the expected parent re-wiring into
+   the benchmarked path only once, outside the loop.
+2. Quantify `Clone` latency. If it's hot in real workloads (it isn't
+   used inside read/write paths, so audit callers first), replace
+   `go-deepcopy` with either:
+   - A generated `Clone()` method on `*MPD` and its substructs —
+     straightforward from the existing XML schema, zero reflection at
+     runtime.
+   - A marshal-then-unmarshal round-trip, which reuses all the other
+     improvements on this list and is only ~2× the cost of marshal+parse.
+
+Cloning is out of scope for the requested read/write focus, but the
+broken benchmark blocks measuring any of the above against the other
+benchmarks in the same `go test -bench=.` run — fix it for workflow
+reasons.
+
+### H11 — Per-byte reads from `bytes.Reader` *(low)*
+
+**Location:** `xml/xml.go:924-945` (`getc`)
+
+CPU profile puts `getc` at 4.42 %, `bytes.(*Reader).ReadByte` at 1.42 %.
+`Unmarshal` wraps the input in a `bytes.Reader` (native `ByteReader`);
+each byte pays one interface call. A custom hot loop that reads a slice
+into a ring would be faster but significantly more invasive in the
+forked parser.
+
+**Recommendation:** leave alone until H1–H4 are done — the allocation
+reductions will also reduce the per-byte CPU overhead indirectly via
+lower GC work.
+
+---
+
+## 4. Suggested ordering
+
+Measured against `BenchmarkUnmarshal`/`BenchmarkMarshal`:
+
+1. **H1** (`ParseDuration` rewrite) — self-contained, high impact,
+   risk-free. Ship first.
+2. **H10** fix the `Clone` benchmark — trivial, but required so we can
+   see regressions in the same run.
+3. **H2.1** pre-size attr slice + **H3.2** pre-size attr slice in
+   marshal — two one-line changes, easy to validate via
+   `-benchmem`.
+4. **H8** attribute-lookup map on `*typeInfo` + **H9** cached
+   `implements` booleans — small change to `xml/typeinfo.go`, removes
+   the most visible non-GC CPU time.
+5. **H3.1 / H3.3** bypass `Attr` for simple attributes — biggest
+   marshal win but touches the hot-path API in `xml/marshal.go`. Needs
+   round-trip tests; the existing `TestDecodeEncodeMPDs` over all
+   testdata MPDs is a good regression net.
+6. **H2.2** name interning on the Decoder — requires a small design
+   call about bounding the intern table; defer until the earlier wins
+   are measured.
+7. **H5 / H6** encoder pool and streaming `Write` — do together; easy
+   follow-up once H3 has landed.
+8. **H11 / H7** low-priority cleanups.
+
+A rough target after H1–H5 is:
+
+- Unmarshal: ~700 allocs → ~350 allocs, ~57 µs → ~40 µs
+- Marshal: ~108 allocs → ~30 allocs, ~26 µs → ~15 µs
+
+Conservative, based on the profile shares above; will need
+re-benchmarking at each step.
+
+---
+
+## 5. Benchmark coverage gaps
+
+The current benchmarks only cover a **single 60-line MPD**. They do not
+exercise the realistic hot paths:
+
+- Large live MPD with a long `SegmentTimeline` (hundreds to thousands
+  of `S` elements per Representation). This is the hot case for DASH
+  packagers / manifest manipulators.
+- Multi-period MPD (SCTE-35 splice points), ~dozens of periods.
+- On-demand profile MPD with many Representations (HDR/SDR/bitrate
+  ladders).
+
+Adding a parametrised benchmark that iterates all files in
+`mpd/testdata/` (or the subset that is semantically realistic) would
+catch regressions that the current benchmarks miss, and would give a
+more honest picture of where optimisations matter.
+
+Additionally:
+- `BenchmarkClone` needs the fix in H10.
+- A `BenchmarkReadFromFile` would let us distinguish I/O from parse
+  cost, relevant once H7's streaming reader lands.
+- A `BenchmarkWrite` that writes to `io.Discard` (rather than
+  marshalling to a buffer) would validate H6.
+
+---
+
+## 6. Summary
+
+The parser/writer are correct and well-tested, but their cost is
+dominated by small, per-element allocations: attribute slices and
+strings in the parser, `Attr` structs and numeric strings in the
+writer, plus a redundant regex pass in `ParseDuration`. None of the
+findings require touching the generated struct tree — all live in
+`xml/*.go`, `mpd/duration.go`, and `mpd/io.go`. Delivering H1 through
+H5 should roughly halve parse allocations and cut marshal allocations
+by ~3-4×, with no behaviour change (the existing round-trip test suite
+over the `testdata` MPDs guards correctness).

--- a/mpd/duration.go
+++ b/mpd/duration.go
@@ -134,7 +134,7 @@ func fmtFrac(buf []byte, v uint64, prec int) (nw int, nv uint64) {
 	// Omit trailing zeros up to and including decimal point.
 	w := len(buf)
 	print := false
-	for i := 0; i < prec; i++ {
+	for range prec {
 		digit := v % 10
 		print = print || digit != 0
 		if print {

--- a/mpd/duration.go
+++ b/mpd/duration.go
@@ -2,9 +2,7 @@ package mpd
 
 import (
 	"math"
-	"regexp"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/Eyevinn/dash-mpd/xml"
@@ -32,18 +30,6 @@ func newParseDurationError(msg string) ParseDurationError {
 //
 // XML marshaling methods need Duration to be included as a pointer in XML.
 type Duration time.Duration
-
-const (
-	rStart   = "^P"          // Must start with a 'P'
-	rDays    = "(\\d+D)?"    // We only allow Days for durations, not Months or Years
-	rTime    = "(?:T"        // If there's any 'time' units then they must be preceded by a 'T'
-	rHours   = "(\\d+H)?"    // Hours
-	rMinutes = "(\\d+M)?"    // Minutes
-	rSeconds = "([\\d.]+S)?" // Seconds (Potentially decimal)
-	rEnd     = ")?$"         // end of regex must close "T" capture group
-)
-
-var xmlDurationRegex = regexp.MustCompile(rStart + rDays + rTime + rHours + rMinutes + rSeconds + rEnd)
 
 func (d *Duration) MarshalXMLAttr(name xml.Name) (xml.Attr, error) {
 	if d == nil {
@@ -128,12 +114,16 @@ func (d *Duration) String() string {
 		}
 	}
 
+	w--
+	buf[w] = 'T'
+	w--
+	buf[w] = 'P'
 	if neg {
 		w--
 		buf[w] = '-'
 	}
 
-	return "PT" + string(buf[w:])
+	return string(buf[w:])
 }
 
 // fmtFrac formats the fraction of v/10**prec (e.g., ".12345") into the
@@ -182,51 +172,120 @@ func ParseDuration(str string) (time.Duration, error) {
 	if len(str) < 3 {
 		return 0, newParseDurationError("at least one number and designator are required")
 	}
-
-	if strings.Contains(str, "-") {
+	if str[0] == '-' {
 		return 0, newParseDurationError("duration cannot be negative")
 	}
-
-	// Check that only the parts we expect exist and that everything's in the correct order
-	if !xmlDurationRegex.Match([]byte(str)) {
+	if str[0] != 'P' {
 		return 0, newParseDurationError("duration must be in the format: P[nD][T[nH][nM][nS]]")
 	}
 
-	var parts = xmlDurationRegex.FindStringSubmatch(str)
-	var total time.Duration
+	var (
+		total    time.Duration
+		i        = 1 // cursor, positioned just after 'P'
+		afterT   = false
+		seenAny  = false
+		lastUnit byte
+	)
 
-	if parts[1] != "" {
-		days, err := strconv.Atoi(strings.TrimRight(parts[1], "D"))
-		if err != nil {
-			return 0, newParseDurationError("error parsing Days")
+	// rank enforces D < H < M < S ordering.
+	rank := func(c byte) int {
+		switch c {
+		case 'D':
+			return 1
+		case 'H':
+			return 2
+		case 'M':
+			return 3
+		case 'S':
+			return 4
 		}
-		total += time.Duration(days) * time.Hour * 24
+		return 0
 	}
 
-	if parts[2] != "" {
-		hours, err := strconv.Atoi(strings.TrimRight(parts[2], "H"))
-		if err != nil {
-			return 0, newParseDurationError("error parsing Hours")
+	for i < len(str) {
+		c := str[i]
+		if c == 'T' {
+			if afterT {
+				return 0, newParseDurationError("duration must be in the format: P[nD][T[nH][nM][nS]]")
+			}
+			afterT = true
+			i++
+			continue
 		}
-		total += time.Duration(hours) * time.Hour
-	}
-
-	if parts[3] != "" {
-		mins, err := strconv.Atoi(strings.TrimRight(parts[3], "M"))
-		if err != nil {
-			return 0, newParseDurationError("error parsing Minutes")
+		if c == '-' {
+			return 0, newParseDurationError("duration cannot be negative")
 		}
-		total += time.Duration(mins) * time.Minute
-	}
-
-	if parts[4] != "" {
-		secs, err := strconv.ParseFloat(strings.TrimRight(parts[4], "S"), 64)
-		if err != nil {
-			return 0, newParseDurationError("error parsing Seconds")
+		// Must now read digits (and maybe '.', only if looking for S).
+		start := i
+		sawDot := false
+		for i < len(str) {
+			b := str[i]
+			if b >= '0' && b <= '9' {
+				i++
+				continue
+			}
+			if b == '.' && !sawDot {
+				sawDot = true
+				i++
+				continue
+			}
+			break
 		}
-		total += time.Duration(secs * float64(time.Second))
-	}
+		if i == start {
+			return 0, newParseDurationError("duration must be in the format: P[nD][T[nH][nM][nS]]")
+		}
+		if i == len(str) {
+			return 0, newParseDurationError("duration must be in the format: P[nD][T[nH][nM][nS]]")
+		}
+		unit := str[i]
+		i++
+		if rank(unit) == 0 {
+			return 0, newParseDurationError("duration must be in the format: P[nD][T[nH][nM][nS]]")
+		}
+		if rank(unit) <= rank(lastUnit) {
+			return 0, newParseDurationError("duration must be in the format: P[nD][T[nH][nM][nS]]")
+		}
+		if unit != 'D' && !afterT {
+			return 0, newParseDurationError("duration must be in the format: P[nD][T[nH][nM][nS]]")
+		}
+		if sawDot && unit != 'S' {
+			return 0, newParseDurationError("duration must be in the format: P[nD][T[nH][nM][nS]]")
+		}
+		lastUnit = unit
+		seenAny = true
 
+		numStr := str[start : i-1] // digits (and maybe '.') without the unit letter
+
+		switch unit {
+		case 'D':
+			n, err := strconv.ParseUint(numStr, 10, 64)
+			if err != nil {
+				return 0, newParseDurationError("error parsing Days")
+			}
+			total += time.Duration(n) * 24 * time.Hour
+		case 'H':
+			n, err := strconv.ParseUint(numStr, 10, 64)
+			if err != nil {
+				return 0, newParseDurationError("error parsing Hours")
+			}
+			total += time.Duration(n) * time.Hour
+		case 'M':
+			n, err := strconv.ParseUint(numStr, 10, 64)
+			if err != nil {
+				return 0, newParseDurationError("error parsing Minutes")
+			}
+			total += time.Duration(n) * time.Minute
+		case 'S':
+			f, err := strconv.ParseFloat(numStr, 64)
+			if err != nil {
+				return 0, newParseDurationError("error parsing Seconds")
+			}
+			total += time.Duration(f * float64(time.Second))
+		}
+	}
+	if !seenAny {
+		return 0, newParseDurationError("at least one number and designator are required")
+	}
 	return total, nil
 }
 

--- a/mpd/duration_test.go
+++ b/mpd/duration_test.go
@@ -64,6 +64,48 @@ func TestParseBadDurations(t *testing.T) {
 	}
 }
 
+func TestParseDurationExtended(t *testing.T) {
+	t.Run("happy path", func(t *testing.T) {
+		cases := []struct {
+			input    string
+			expected float64
+		}{
+			{"PT0S", 0},
+			{"P1D", (24 * time.Hour).Seconds()},
+			{"PT1H", time.Hour.Seconds()},
+			{"PT1M", time.Minute.Seconds()},
+			{"PT1S", time.Second.Seconds()},
+			{"PT0.5S", 0.5},
+			{"P1DT2H3M4.5S", (24*time.Hour + 2*time.Hour + 3*time.Minute + 4*time.Second + 500*time.Millisecond).Seconds()},
+		}
+		for _, tc := range cases {
+			act, err := ParseDuration(tc.input)
+			require.NoError(t, err, tc.input)
+			require.InDelta(t, tc.expected, act.Seconds(), 1e-9, tc.input)
+		}
+	})
+
+	t.Run("error cases", func(t *testing.T) {
+		cases := []string{
+			"",
+			"P",
+			"PT",
+			"P1M",    // M before T
+			"PT1.5M", // decimal not on S
+			"P1H",    // H before T
+			"P-1D",   // negative value inside
+			"P1D2H",  // H before T (no T separator)
+			"P1Y",    // unsupported unit Y
+			"P1S1H",  // order: S before H not valid
+			"P1D1D",  // duplicate D
+		}
+		for _, tc := range cases {
+			_, err := ParseDuration(tc)
+			require.Error(t, err, "expected error for: %s", tc)
+		}
+	})
+}
+
 func TestUnMarshalReMarshalDuration(t *testing.T) {
 	cases := []string{
 		"PT0.0002S",

--- a/mpd/io.go
+++ b/mpd/io.go
@@ -3,10 +3,23 @@ package mpd
 import (
 	"io"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/Eyevinn/dash-mpd/xml"
 )
+
+// countingWriter wraps an io.Writer and counts the bytes written.
+type countingWriter struct {
+	w io.Writer
+	n int
+}
+
+func (cw *countingWriter) Write(p []byte) (int, error) {
+	n, err := cw.w.Write(p)
+	cw.n += n
+	return n, err
+}
 
 // ReadFromFile reads and unmarshals an MPD from a file.
 func ReadFromFile(path string) (*MPD, error) {
@@ -39,35 +52,38 @@ func MPDFromBytes(data []byte) (*MPD, error) {
 	return &mpd, nil
 }
 
-// Write writes to w, with indentation according to indent and optionally adding an XML header.
-func (m *MPD) Write(w io.Writer, indent string, withHeader bool) (n int, err error) {
-	data, err := xml.MarshalIndent(m, "", indent)
-	if err != nil {
-		return 0, err
-	}
-	nTot := 0
+// Write streams the XML encoding of m to w, with indentation according to indent
+// and optionally prefixing an XML declaration header.  It returns the number of
+// bytes written.  The encoder is pooled for efficiency; do not hold w open after
+// Write returns.
+func (m *MPD) Write(w io.Writer, indent string, withHeader bool) (int, error) {
+	cw := &countingWriter{w: w}
 	if withHeader {
-		n, err = w.Write([]byte(xml.Header))
-		if err != nil {
-			return n, err
+		if _, err := io.WriteString(cw, xml.Header); err != nil {
+			return cw.n, err
 		}
-		nTot += n
 	}
-	n, err = w.Write(data)
-	nTot += n
-	return nTot, err
+	enc := xml.AcquireEncoder(cw)
+	defer xml.ReleaseEncoder(enc)
+	enc.Indent("", indent)
+	if err := enc.Encode(m); err != nil {
+		return cw.n, err
+	}
+	if err := enc.Flush(); err != nil {
+		return cw.n, err
+	}
+	return cw.n, nil
 }
 
-// WriteToString returns a string, with indentation according to indent and optionally adding an XML header.
+// WriteToString returns the XML encoding of m as a string, with indentation
+// according to indent and optionally prefixing an XML declaration header.
 func (m *MPD) WriteToString(indent string, withHeader bool) (string, error) {
-	data, err := xml.MarshalIndent(m, "", indent)
-	if err != nil {
+	var sb strings.Builder
+	sb.Grow(4096)
+	if _, err := m.Write(&sb, indent, withHeader); err != nil {
 		return "", err
 	}
-	if withHeader {
-		return xml.Header + string(data), nil
-	}
-	return string(data), nil
+	return sb.String(), nil
 }
 
 const RFC3339MS string = "2006-01-02T15:04:05.999Z07:00"

--- a/mpd/mpd_test.go
+++ b/mpd/mpd_test.go
@@ -2,8 +2,10 @@ package mpd_test
 
 import (
 	"bytes"
+	"io"
 	"io/fs"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/Eyevinn/dash-mpd/xml"
@@ -181,6 +183,49 @@ func TestSegmentTemplateTimescale(t *testing.T) {
 		st.SetTimescale(tc.timescale)
 		gotTimescale := st.GetTimescale()
 		require.Equal(t, tc.timescale, gotTimescale)
+	}
+}
+
+func BenchmarkUnmarshalCorpus(b *testing.B) {
+	files, err := filepath.Glob("testdata/schema-mpds/*.mpd")
+	require.NoError(b, err)
+	for _, f := range files {
+		data, err := os.ReadFile(f)
+		require.NoError(b, err)
+		b.Run(filepath.Base(f), func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				mpd := m.MPD{}
+				_ = xml.Unmarshal(data, &mpd)
+			}
+		})
+	}
+}
+
+func BenchmarkMarshalCorpus(b *testing.B) {
+	files, err := filepath.Glob("testdata/schema-mpds/*.mpd")
+	require.NoError(b, err)
+	for _, f := range files {
+		data, err := os.ReadFile(f)
+		require.NoError(b, err)
+		mpd := m.MPD{}
+		err = xml.Unmarshal(data, &mpd)
+		require.NoError(b, err)
+		b.Run(filepath.Base(f), func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				_, _ = xml.MarshalIndent(mpd, "", "  ")
+			}
+		})
+	}
+}
+
+func BenchmarkWriteToDiscard(b *testing.B) {
+	mpd, err := m.ReadFromFile("testdata/schema-mpds/example_G15.mpd")
+	require.NoError(b, err)
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_, _ = mpd.Write(io.Discard, "  ", true)
 	}
 }
 

--- a/mpd/mpd_test.go
+++ b/mpd/mpd_test.go
@@ -121,8 +121,6 @@ func BenchmarkClone(b *testing.B) {
 	mpd := m.MPD{}
 	err = xml.Unmarshal(data, &mpd)
 	require.NoError(b, err)
-	mpdCopy := m.Clone(&mpd)
-	cmp.Equal(&mpd, mpdCopy)
 	for i := 0; i < b.N; i++ {
 		_ = m.Clone(&mpd)
 	}

--- a/xml/marshal.go
+++ b/xml/marshal.go
@@ -731,8 +731,7 @@ func (p *printer) marshalAttr(start *StartElement, name Name, val reflect.Value)
 
 	// Walk slices.
 	if val.Kind() == reflect.Slice && val.Type().Elem().Kind() != reflect.Uint8 {
-		n := val.Len()
-		for i := 0; i < n; i++ {
+		for i := range val.Len() {
 			if err := p.marshalAttr(start, name, val.Index(i)); err != nil {
 				return err
 			}

--- a/xml/marshal.go
+++ b/xml/marshal.go
@@ -14,6 +14,7 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
+	"sync"
 )
 
 const (
@@ -152,6 +153,48 @@ func NewEncoder(w io.Writer) *Encoder {
 	e := &Encoder{printer{w: bufio.NewWriter(w)}}
 	e.p.encoder = e
 	return e
+}
+
+// encoderPool is a pool of *Encoder values.  Each pooled encoder holds a
+// bufio.Writer whose underlying writer is io.Discard; AcquireEncoder redirects
+// that writer to the caller's io.Writer before returning the encoder.
+var encoderPool = sync.Pool{
+	New: func() any {
+		e := &Encoder{printer{w: bufio.NewWriter(io.Discard)}}
+		e.p.encoder = e
+		return e
+	},
+}
+
+// AcquireEncoder returns a pooled *Encoder configured to write to w.
+// The caller must call ReleaseEncoder when done to return it to the pool.
+// Do not continue to use the encoder after calling ReleaseEncoder.
+func AcquireEncoder(w io.Writer) *Encoder {
+	enc := encoderPool.Get().(*Encoder)
+	enc.p.w.Reset(w)
+	enc.p.closed = false
+	enc.p.err = nil
+	return enc
+}
+
+// ReleaseEncoder resets enc's internal state and returns it to the pool.
+// The caller must not use enc after this call.
+func ReleaseEncoder(enc *Encoder) {
+	// Reset the bufio.Writer to discard so the pooled encoder holds no
+	// reference to the caller's writer.
+	enc.p.w.Reset(io.Discard)
+	// Clear all mutable printer state.
+	enc.p.seq = 0
+	enc.p.indent = ""
+	enc.p.prefix = ""
+	enc.p.depth = 0
+	enc.p.indentedIn = false
+	enc.p.putNewline = false
+	enc.p.closed = false
+	enc.p.err = nil
+	// Truncate the elements slice without releasing its backing array.
+	enc.p.elements = enc.p.elements[:0]
+	encoderPool.Put(enc)
 }
 
 // Indent sets the encoder to generate XML in which each element
@@ -1225,7 +1268,7 @@ func (s *parentStack) trim(parents []string) error {
 
 // push adds parent elements to the stack and writes open tags.
 func (s *parentStack) push(parents []string) error {
-	for i := 0; i < len(parents); i++ {
+	for i := range parents {
 		if err := s.p.writeStart(&StartElement{Name: Name{Local: parents[i]}}); err != nil {
 			return err
 		}

--- a/xml/marshal.go
+++ b/xml/marshal.go
@@ -490,23 +490,24 @@ func (p *printer) marshalValue(val reflect.Value, finfo *fieldInfo, startTemplat
 	typ := val.Type()
 
 	// Check for marshaler.
-	if val.CanInterface() && typ.Implements(marshalerType) {
+	ti := getTypeImpl(typ)
+	if val.CanInterface() && ti.marshaler {
 		return p.marshalInterface(val.Interface().(Marshaler), defaultStart(typ, finfo, startTemplate))
 	}
 	if val.CanAddr() {
 		pv := val.Addr()
-		if pv.CanInterface() && pv.Type().Implements(marshalerType) {
+		if pv.CanInterface() && ti.addrMarshaler {
 			return p.marshalInterface(pv.Interface().(Marshaler), defaultStart(pv.Type(), finfo, startTemplate))
 		}
 	}
 
 	// Check for text marshaler.
-	if val.CanInterface() && typ.Implements(textMarshalerType) {
+	if val.CanInterface() && ti.textMarshaler {
 		return p.marshalTextInterface(val.Interface().(encoding.TextMarshaler), defaultStart(typ, finfo, startTemplate))
 	}
 	if val.CanAddr() {
 		pv := val.Addr()
-		if pv.CanInterface() && pv.Type().Implements(textMarshalerType) {
+		if pv.CanInterface() && ti.addrTextMarshaler {
 			return p.marshalTextInterface(pv.Interface().(encoding.TextMarshaler), defaultStart(pv.Type(), finfo, startTemplate))
 		}
 	}
@@ -563,6 +564,11 @@ func (p *printer) marshalValue(val reflect.Value, finfo *fieldInfo, startTemplat
 			return &UnsupportedTypeError{typ}
 		}
 		start.Name.Local = name
+	}
+
+	// Pre-size start.Attr to avoid repeated backing-array copies.
+	if cap(start.Attr) < tinfo.nAttrs {
+		start.Attr = make([]Attr, 0, tinfo.nAttrs)
 	}
 
 	// Attributes
@@ -624,7 +630,8 @@ func (p *printer) marshalValue(val reflect.Value, finfo *fieldInfo, startTemplat
 
 // marshalAttr marshals an attribute with the given name and value, adding to start.Attr.
 func (p *printer) marshalAttr(start *StartElement, name Name, val reflect.Value) error {
-	if val.CanInterface() && val.Type().Implements(marshalerAttrType) {
+	tai := getTypeImpl(val.Type())
+	if val.CanInterface() && tai.marshalerAttr {
 		attr, err := val.Interface().(MarshalerAttr).MarshalXMLAttr(name)
 		if err != nil {
 			return err
@@ -637,7 +644,7 @@ func (p *printer) marshalAttr(start *StartElement, name Name, val reflect.Value)
 
 	if val.CanAddr() {
 		pv := val.Addr()
-		if pv.CanInterface() && pv.Type().Implements(marshalerAttrType) {
+		if pv.CanInterface() && tai.addrMarshalerAttr {
 			attr, err := pv.Interface().(MarshalerAttr).MarshalXMLAttr(name)
 			if err != nil {
 				return err
@@ -649,7 +656,7 @@ func (p *printer) marshalAttr(start *StartElement, name Name, val reflect.Value)
 		}
 	}
 
-	if val.CanInterface() && val.Type().Implements(textMarshalerType) {
+	if val.CanInterface() && tai.textMarshaler {
 		text, err := val.Interface().(encoding.TextMarshaler).MarshalText()
 		if err != nil {
 			return err
@@ -660,7 +667,7 @@ func (p *printer) marshalAttr(start *StartElement, name Name, val reflect.Value)
 
 	if val.CanAddr() {
 		pv := val.Addr()
-		if pv.CanInterface() && pv.Type().Implements(textMarshalerType) {
+		if pv.CanInterface() && tai.addrTextMarshaler {
 			text, err := pv.Interface().(encoding.TextMarshaler).MarshalText()
 			if err != nil {
 				return err

--- a/xml/read.go
+++ b/xml/read.go
@@ -476,31 +476,23 @@ func (d *Decoder) unmarshal(val reflect.Value, start *StartElement, depth int) e
 			}
 		}
 
-		// Assign attributes.
+		// Assign attributes using the O(1) map on typeInfo.
 		for _, a := range start.Attr {
-			handled := false
-			any := -1
-			for i := range tinfo.fields {
-				finfo := &tinfo.fields[i]
-				switch finfo.flags & fMode {
-				case fAttr:
-					strv := finfo.value(sv, initNilPointers)
-					if a.Name.Local == finfo.name && (finfo.xmlns == "" || finfo.xmlns == a.Name.Space) {
-						if err := d.unmarshalAttr(strv, a); err != nil {
-							return err
-						}
-						handled = true
-					}
-
-				case fAny | fAttr:
-					if any == -1 {
-						any = i
-					}
-				}
+			// Try exact match (namespace + local name) first.
+			fi, ok := tinfo.attrs[attrKey{a.Name.Space, a.Name.Local}]
+			if !ok {
+				// A field registered with empty xmlns matches any namespace.
+				fi, ok = tinfo.attrs[attrKey{"", a.Name.Local}]
 			}
-			if !handled && any >= 0 {
-				finfo := &tinfo.fields[any]
-				strv := finfo.value(sv, initNilPointers)
+			if ok {
+				strv := fi.value(sv, initNilPointers)
+				if err := d.unmarshalAttr(strv, a); err != nil {
+					return err
+				}
+				continue
+			}
+			if tinfo.anyAttr != nil {
+				strv := tinfo.anyAttr.value(sv, initNilPointers)
 				if err := d.unmarshalAttr(strv, a); err != nil {
 					return err
 				}

--- a/xml/typeinfo.go
+++ b/xml/typeinfo.go
@@ -98,7 +98,7 @@ func getTypeInfo(typ reflect.Type) (*typeInfo, error) {
 	tinfo := &typeInfo{}
 	if typ.Kind() == reflect.Struct && typ != nameType {
 		n := typ.NumField()
-		for i := 0; i < n; i++ {
+		for i := range n {
 			f := typ.Field(i)
 			if (!f.IsExported() && !f.Anonymous) || f.Tag.Get("xml") == "-" {
 				continue // Private field
@@ -333,7 +333,7 @@ Loop:
 			continue
 		}
 		minl := min(len(newf.parents), len(oldf.parents))
-		for p := 0; p < minl; p++ {
+		for p := range minl {
 			if oldf.parents[p] != newf.parents[p] {
 				continue Loop
 			}

--- a/xml/typeinfo.go
+++ b/xml/typeinfo.go
@@ -11,10 +11,19 @@ import (
 	"sync"
 )
 
+// attrKey is the map key used for O(1) attribute lookup.
+type attrKey struct {
+	space string
+	local string
+}
+
 // typeInfo holds details for the xml representation of a type.
 type typeInfo struct {
 	xmlname *fieldInfo
 	fields  []fieldInfo
+	nAttrs  int                    // number of fAttr fields; populated at end of getTypeInfo
+	attrs   map[attrKey]*fieldInfo // keyed by (xmlns, name); populated at end of getTypeInfo
+	anyAttr *fieldInfo             // first fAny|fAttr field, nil if none
 }
 
 // fieldInfo holds details for the xml representation of a single field.
@@ -46,6 +55,36 @@ const (
 )
 
 var tinfoMap sync.Map // map[reflect.Type]*typeInfo
+
+// typeImpl caches reflect.Type.Implements results for marshaler
+// interfaces. The checks are deterministic per type, so computing them once
+// and storing the booleans avoids repeated reflect calls in hot paths.
+type typeImpl struct {
+	marshaler, addrMarshaler,
+	marshalerAttr, addrMarshalerAttr,
+	textMarshaler, addrTextMarshaler bool
+}
+
+var typeImplMap sync.Map // map[reflect.Type]typeImpl
+
+// getTypeImpl returns (and caches) the typeImpl for t.
+// It is safe for concurrent use.
+func getTypeImpl(t reflect.Type) typeImpl {
+	if v, ok := typeImplMap.Load(t); ok {
+		return v.(typeImpl)
+	}
+	pt := reflect.PointerTo(t)
+	v := typeImpl{
+		marshaler:         t.Implements(marshalerType),
+		addrMarshaler:     pt.Implements(marshalerType),
+		marshalerAttr:     t.Implements(marshalerAttrType),
+		addrMarshalerAttr: pt.Implements(marshalerAttrType),
+		textMarshaler:     t.Implements(textMarshalerType),
+		addrTextMarshaler: pt.Implements(textMarshalerType),
+	}
+	typeImplMap.Store(t, v)
+	return v
+}
 
 var nameType = reflect.TypeFor[Name]()
 
@@ -100,6 +139,25 @@ func getTypeInfo(typ reflect.Type) (*typeInfo, error) {
 			} else if err := addFieldInfo(typ, tinfo, finfo); err != nil {
 				// Add the field if it doesn't conflict with other fields.
 				return nil, err
+			}
+		}
+	}
+
+	// Count fAttr fields so marshalValue can pre-size start.Attr,
+	// and build a map for O(1) attribute lookup during unmarshal.
+	tinfo.attrs = make(map[attrKey]*fieldInfo, len(tinfo.fields))
+	for i := range tinfo.fields {
+		fi := &tinfo.fields[i]
+		switch fi.flags & fMode {
+		case fAttr:
+			tinfo.nAttrs++
+			// Register under (fi.xmlns, fi.name). Lookup in read.go will
+			// try (a.Name.Space, fi.name) first, then ("", fi.name) for
+			// fields registered with an empty namespace.
+			tinfo.attrs[attrKey{fi.xmlns, fi.name}] = fi
+		case fAny | fAttr:
+			if tinfo.anyAttr == nil {
+				tinfo.anyAttr = fi
 			}
 		}
 	}

--- a/xml/xml.go
+++ b/xml/xml.go
@@ -216,6 +216,29 @@ type Decoder struct {
 	linestart      int64
 	offset         int64
 	unmarshalDepth int
+	nameIntern     map[string]string // per-Decoder intern map for element/attribute names
+}
+
+const maxInternEntries = 1024
+
+// internBytes returns a string for b, interning it in the per-Decoder map so
+// that repeated occurrences of the same name (element name, attribute name,
+// namespace URI) share a single allocation.  Attribute values and character
+// data must NOT be interned because their cardinality is unbounded.
+func (d *Decoder) internBytes(b []byte) string {
+	if d.nameIntern == nil {
+		d.nameIntern = make(map[string]string, 128)
+	}
+	// The string(b) conversion in a map key is compiler-optimised since Go 1.5:
+	// it does not allocate when used only as a map key.
+	if s, ok := d.nameIntern[string(b)]; ok {
+		return s
+	}
+	s := string(b)
+	if len(d.nameIntern) < maxInternEntries {
+		d.nameIntern[s] = s
+	}
+	return s
 }
 
 // NewDecoder creates a new XML parser reading from r.
@@ -807,7 +830,7 @@ func (d *Decoder) rawToken() (Token, error) {
 		return nil, d.err
 	}
 
-	attr = []Attr{}
+	attr = make([]Attr, 0, 8)
 	for {
 		d.space()
 		if b, ok = d.mustgetc(); !ok {
@@ -1223,7 +1246,7 @@ func (d *Decoder) name() (s string, ok bool) {
 		d.err = d.syntaxError("invalid XML name: " + string(b))
 		return "", false
 	}
-	return string(b), true
+	return d.internBytes(b), true
 }
 
 // Read a name and append its bytes to d.buf.

--- a/xml/xml.go
+++ b/xml/xml.go
@@ -728,7 +728,7 @@ func (d *Decoder) rawToken() (Token, error) {
 
 		case '[': // <![
 			// Probably <![CDATA[.
-			for i := 0; i < 6; i++ {
+			for i := range 6 {
 				if b, ok = d.mustgetc(); !ok {
 					return nil, d.err
 				}


### PR DESCRIPTION
## Summary

Consolidates the DASH Ed.6 schema refresh, a performance audit, and the resulting xml/mpd Marshal/Unmarshal optimizations into one PR. Eight commits, each a self-contained logical group.

## Commits

| # | Commit | What |
|---|--------|------|
| 1 | `feat: align types and testdata with DASH Ed.6 schema` | MPD type updates + refreshed example MPDs to match `MPEGGroup/DASHSchema` 6th-Ed `a855144` (2026-04-22). Adds `ContentSteering` on MPD, `BaseURL` on `EventStream`, `k` on `MultipleSegmentBaseType`, `minBufferTime` on `Period`. Drops `EventRestrictionsType`, `kL`/`sspL`, etc. |
| 2 | `docs: add performance audit report and improvement plan` | Baseline analysis (H1–H11) and sequenced plan in `discovery/`. |
| 3 | `fix: remove infinite-recursion crash in BenchmarkClone` | Lets the benchmark suite actually run. |
| 4 | `perf(mpd): rewrite ParseDuration without regex; trim Duration.String concat` | Single-pass scanner — no regex, zero allocs in the happy path. `Duration.String` writes `P`/`T` directly into the stack buffer instead of `"PT" + string(...)`. |
| 5 | `perf(xml): cache attribute metadata on typeInfo; intern decoder names` | `typeInfo` gains `nAttrs` (pre-size `start.Attr`), `attrs` map (O(1) unmarshal attribute lookup), and a `sync.Map`-backed `Implements`-check cache. Per-`Decoder` string intern for element/attribute names (cap 1024). Pre-sizes the parser `[]Attr` to cap 8. |
| 6 | `perf(xml): pool Encoder and stream MPD.Write directly` | `sync.Pool` of `*Encoder` via `AcquireEncoder`/`ReleaseEncoder` removes the 4 KiB `bufio.Writer` allocation per call. `(*MPD).Write` streams through a `countingWriter` — no intermediate `[]byte`. `WriteToString` is backed by `strings.Builder`. |
| 7 | `style: modernize Go idioms in changed code` | `any`, `reflect.Pointer`, `reflect.TypeFor`, range-over-int — only in files already touched by this PR. No behaviour change. |
| 8 | `test(mpd): add corpus and streaming benchmarks` | `BenchmarkUnmarshalCorpus` / `BenchmarkMarshalCorpus` sub-benchmark every `testdata/schema-mpds/*.mpd`. `BenchmarkWriteToDiscard` exercises the streaming `(*MPD).Write` path. |

## Measured impact (M4 Pro, `example_G15.mpd`)

| Benchmark | Pre-PR | After PR | Delta |
|-----------|--------|----------|-------|
| `BenchmarkUnmarshal` | 53.4 µs / 681 allocs | 44.4 µs / 552 allocs | **−17 % time, −19 % allocs** |
| `BenchmarkMarshal` | 26.4 µs / 109 allocs | 23.6 µs / 62 allocs | **−11 % time, −43 % allocs** |
| `BenchmarkWriteToDiscard` | n/a (new) | 23.4 µs / 54 allocs | — |

The original plan-step #7 ("bypass `Attr` alloc for simple attributes") was implemented but measured to **regress** `BenchmarkMarshal` by +21 % time / +174 % allocs (the `[]byte(val.String())` conversion in the per-attr write path allocates more than the path it replaced). It was reverted before merging — every other plan step landed.

## Out of scope (intentional)

- The Ed.6 schema refresh is bundled with the performance pass rather than landed separately. The two share `testdata/schema-mpds/*.mpd`, so splitting them would require maintaining parallel testdata sets.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./...` passes on the tip
- [x] `TestDecodeEncodeMPDs` round-trips every MPD in `testdata/` after each commit
- [x] `TestParseDurationExtended` covers happy-path and error cases for the new scanner
- [x] `BenchmarkMarshal` / `BenchmarkUnmarshal` measured before and after on `example_G15.mpd`
