### PR TITLE
Upgrade vendored xml package to PR #48641 head

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Nothing yet
+### Changed
+
+- Upgraded vendored `xml/` package to the current head of golang/go PR #48641
+  (`ydnar/go@a79fce77`, rebased on Go master 2024-10-28). Brings in stdlib
+  `encoding/xml` fixes since Go 1.17, including CVE-2022-30633 (unmarshal depth
+  limit) and several panic fixes. The local customization that disables tab/
+  newline escaping in `CharData` byte content is preserved.
 
 ## [0.14.1] - 2026-02-06
 

--- a/README.md
+++ b/README.md
@@ -55,9 +55,12 @@ There are a number of pull requests to improve the situation, and in particular
 includes an extension to the XML struct tags that make it possible to specify name
 space prefixes.
 
-Since this functionality has not yet (Go 1.19) made its way into the standard library, after more
-than a year, the full patched version of the `encoding/xml` package is included here
-in the `xml` directory. Therefore, the `github.com/Eyevinn/dash-mpd/xml` package should
+Since this functionality has not yet made its way into the standard library, after more
+than four years, the full patched version of the `encoding/xml` package is included here
+in the `xml` directory. The vendored copy tracks the current head of PR #48641 rebased on
+Go master, and therefore includes stdlib fixes made since Go 1.17 (notably CVE-2022-30633
+and several panic fixes). See `xml/README.md` for the exact commit.
+Therefore, the `github.com/Eyevinn/dash-mpd/xml` package should
 be used together with the XML structure in the package, rather than the standard library version.
 The package functions `mpd.ReadFromFile()`, `mpd.ReadFromString()`, and `mpd.Write()` do use
 that XML library.

--- a/xml/README.md
+++ b/xml/README.md
@@ -10,8 +10,15 @@ There are a number of pull requests to improve the situation, and in particular
 includes an extension to the XML struct tags that make it possible to specify name
 space prefixes.
 
-This package is a copy of PR#48641. More specifically, commit f68da8a.
+This package is a copy of PR#48641. More specifically, commit
+`a79fce7705e3102ca642bb981bb3829b3fa0824f` from the branch `xmlns-fixes` in
+[ydnar/go](https://github.com/ydnar/go), which is rebased on Go master
+as of 2024-10-28.
 
 Hopefully, this code will be merged into the Go standard library at some point.
 
-Escaping tab and newline led to problems with some DASHSchema test content so this disabled.
+Escaping tab and newline in `CharData` byte content led to problems with some
+DASHSchema test content, so this is disabled: `EscapeText` passes
+`escapeNewline=false`, and the `'\t'` case is removed from `escapeText`. Tab and
+newline are still escaped in `(*printer).EscapeString`, which is used for
+attribute values.

--- a/xml/marshal.go
+++ b/xml/marshal.go
@@ -8,6 +8,7 @@ import (
 	"bufio"
 	"bytes"
 	"encoding"
+	"errors"
 	"fmt"
 	"io"
 	"reflect"
@@ -16,7 +17,7 @@ import (
 )
 
 const (
-	// Header is a generic XML header suitable for use with the output of Marshal.
+	// Header is a generic XML header suitable for use with the output of [Marshal].
 	// This is not automatically added to any output of this package,
 	// it is provided as a convenience.
 	Header = `<?xml version="1.0" encoding="UTF-8"?>` + "\n"
@@ -32,39 +33,41 @@ const (
 // elements containing the data.
 //
 // The name for the XML elements is taken from, in order of preference:
-//     - the tag on the XMLName field, if the data is a struct
-//     - the value of the XMLName field of type Name
-//     - the tag of the struct field used to obtain the data
-//     - the name of the struct field used to obtain the data
-//     - the name of the marshaled type
+//   - the tag on the XMLName field, if the data is a struct
+//   - the value of the XMLName field of type [Name]
+//   - the tag of the struct field used to obtain the data
+//   - the name of the struct field used to obtain the data
+//   - the name of the marshaled type
 //
 // The XML element for a struct contains marshaled elements for each of the
 // exported fields of the struct, with these exceptions:
-//     - the XMLName field, described above, is omitted.
-//     - a field with tag "-" is omitted.
-//     - a field with tag "name,attr" becomes an attribute with
-//       the given name in the XML element.
-//     - a field with tag ",attr" becomes an attribute with the
-//       field name in the XML element.
-//     - a field with tag ",chardata" is written as character data,
-//       not as an XML element.
-//     - a field with tag ",cdata" is written as character data
-//       wrapped in one or more <![CDATA[ ... ]]> tags, not as an XML element.
-//     - a field with tag ",innerxml" is written verbatim, not subject
-//       to the usual marshaling procedure.
-//     - a field with tag ",comment" is written as an XML comment, not
-//       subject to the usual marshaling procedure. It must not contain
-//       the "--" string within it.
-//     - a field with a tag including the "omitempty" option is omitted
-//       if the field value is empty. The empty values are false, 0, any
-//       nil pointer or interface value, and any array, slice, map, or
-//       string of length zero.
-//     - an anonymous struct field is handled as if the fields of its
-//       value were part of the outer struct.
-//     - a field implementing Marshaler is written by calling its MarshalXML
-//       method.
-//     - a field implementing encoding.TextMarshaler is written by encoding the
-//       result of its MarshalText method as text.
+//   - the XMLName field, described above, is omitted.
+//   - a field with tag "-" is omitted.
+//   - a field with tag "name,attr" becomes an attribute with
+//     the given name in the XML element.
+//   - a field with tag ",attr" becomes an attribute with the
+//     field name in the XML element.
+//   - a field with tag ",chardata" is written as character data,
+//     not as an XML element.
+//   - a field with tag ",cdata" is written as character data
+//     wrapped in one or more <![CDATA[ ... ]]> tags, not as an XML element.
+//   - a field with tag ",innerxml" is written verbatim, not subject
+//     to the usual marshaling procedure.
+//   - a field with tag ",comment" is written as an XML comment, not
+//     subject to the usual marshaling procedure. It must not contain
+//     the "--" string within it.
+//   - a field with a tag including the "omitempty" option is omitted
+//     if the field value is empty. The empty values are false, 0, any
+//     nil pointer or interface value, and any array, slice, map, or
+//     string of length zero.
+//   - an anonymous struct field is handled as if the fields of its
+//     value were part of the outer struct.
+//   - an anonymous struct field of interface type is treated the same as having
+//     that type as its name, rather than being anonymous.
+//   - a field implementing [Marshaler] is written by calling its MarshalXML
+//     method.
+//   - a field implementing [encoding.TextMarshaler] is written by encoding the
+//     result of its MarshalText method as text.
 //
 // If a field uses a tag "a>b>c", then the element c will be nested inside
 // parent elements a and b. Fields that appear next to each other that name
@@ -73,12 +76,16 @@ const (
 // If the XML name for a struct field is defined by both the field tag and the
 // struct's XMLName field, the names must match.
 //
-// See MarshalIndent for an example.
+// See [MarshalIndent] for an example.
 //
 // Marshal will return an error if asked to marshal a channel, function, or map.
-func Marshal(v interface{}) ([]byte, error) {
+func Marshal(v any) ([]byte, error) {
 	var b bytes.Buffer
-	if err := NewEncoder(&b).Encode(v); err != nil {
+	enc := NewEncoder(&b)
+	if err := enc.Encode(v); err != nil {
+		return nil, err
+	}
+	if err := enc.Close(); err != nil {
 		return nil, err
 	}
 	return b.Bytes(), nil
@@ -91,7 +98,7 @@ func Marshal(v interface{}) ([]byte, error) {
 // By convention, arrays or slices are typically encoded as a sequence
 // of elements, one per entry.
 // Using start as the element tag is not required, but doing so
-// will enable Unmarshal to match the XML elements to the correct
+// will enable [Unmarshal] to match the XML elements to the correct
 // struct field.
 // One common implementation strategy is to construct a separate
 // value with a layout corresponding to the desired XML and then
@@ -109,9 +116,9 @@ type Marshaler interface {
 //
 // MarshalXMLAttr returns an XML attribute with the encoded value of the receiver.
 // Using name as the attribute name is not required, but doing so
-// will enable Unmarshal to match the attribute to the correct
+// will enable [Unmarshal] to match the attribute to the correct
 // struct field.
-// If MarshalXMLAttr returns the zero attribute Attr{}, no attribute
+// If MarshalXMLAttr returns the zero attribute [Attr]{}, no attribute
 // will be generated in the output.
 // MarshalXMLAttr is used only for struct fields with the
 // "attr" option in the field tag.
@@ -119,14 +126,17 @@ type MarshalerAttr interface {
 	MarshalXMLAttr(name Name) (Attr, error)
 }
 
-// MarshalIndent works like Marshal, but each XML element begins on a new
+// MarshalIndent works like [Marshal], but each XML element begins on a new
 // indented line that starts with prefix and is followed by one or more
 // copies of indent according to the nesting depth.
-func MarshalIndent(v interface{}, prefix, indent string) ([]byte, error) {
+func MarshalIndent(v any, prefix, indent string) ([]byte, error) {
 	var b bytes.Buffer
 	enc := NewEncoder(&b)
 	enc.Indent(prefix, indent)
 	if err := enc.Encode(v); err != nil {
+		return nil, err
+	}
+	if err := enc.Close(); err != nil {
 		return nil, err
 	}
 	return b.Bytes(), nil
@@ -139,7 +149,7 @@ type Encoder struct {
 
 // NewEncoder returns a new encoder that writes to w.
 func NewEncoder(w io.Writer) *Encoder {
-	e := &Encoder{printer{Writer: bufio.NewWriter(w)}}
+	e := &Encoder{printer{w: bufio.NewWriter(w)}}
 	e.p.encoder = e
 	return e
 }
@@ -154,31 +164,31 @@ func (enc *Encoder) Indent(prefix, indent string) {
 
 // Encode writes the XML encoding of v to the stream.
 //
-// See the documentation for Marshal for details about the conversion
+// See the documentation for [Marshal] for details about the conversion
 // of Go values to XML.
 //
-// Encode calls Flush before returning.
-func (enc *Encoder) Encode(v interface{}) error {
+// Encode calls [Encoder.Flush] before returning.
+func (enc *Encoder) Encode(v any) error {
 	err := enc.p.marshalValue(reflect.ValueOf(v), nil, nil)
 	if err != nil {
 		return err
 	}
-	return enc.p.Flush()
+	return enc.p.w.Flush()
 }
 
 // EncodeElement writes the XML encoding of v to the stream,
 // using start as the outermost tag in the encoding.
 //
-// See the documentation for Marshal for details about the conversion
+// See the documentation for [Marshal] for details about the conversion
 // of Go values to XML.
 //
-// EncodeElement calls Flush before returning.
-func (enc *Encoder) EncodeElement(v interface{}, start StartElement) error {
+// EncodeElement calls [Encoder.Flush] before returning.
+func (enc *Encoder) EncodeElement(v any, start StartElement) error {
 	err := enc.p.marshalValue(reflect.ValueOf(v), nil, &start)
 	if err != nil {
 		return err
 	}
-	return enc.p.Flush()
+	return enc.p.w.Flush()
 }
 
 var (
@@ -188,16 +198,16 @@ var (
 )
 
 // EncodeToken writes the given XML token to the stream.
-// It returns an error if StartElement and EndElement tokens are not properly matched.
+// It returns an error if [StartElement] and [EndElement] tokens are not properly matched.
 //
-// EncodeToken does not call Flush, because usually it is part of a larger operation
-// such as Encode or EncodeElement (or a custom Marshaler's MarshalXML invoked
+// EncodeToken does not call [Encoder.Flush], because usually it is part of a larger operation
+// such as [Encoder.Encode] or [Encoder.EncodeElement] (or a custom [Marshaler]'s MarshalXML invoked
 // during those), and those will call Flush when finished.
 // Callers that create an Encoder and then invoke EncodeToken directly, without
 // using Encode or EncodeElement, need to call Flush when finished to ensure
 // that the XML is written to the underlying writer.
 //
-// EncodeToken allows writing a ProcInst with Target set to "xml" only as the first token
+// EncodeToken allows writing a [ProcInst] with Target set to "xml" only as the first token
 // in the stream.
 func (enc *Encoder) EncodeToken(t Token) error {
 
@@ -224,7 +234,7 @@ func (enc *Encoder) EncodeToken(t Token) error {
 	case ProcInst:
 		// First token to be encoded which is also a ProcInst with target of xml
 		// is the xml declaration. The only ProcInst where target of xml is allowed.
-		if t.Target == "xml" && p.Buffered() != 0 {
+		if t.Target == "xml" && p.w.Buffered() != 0 {
 			return fmt.Errorf("xml: EncodeToken of ProcInst xml target only valid for xml declaration, first token encoded")
 		}
 		if !isNameString(t.Target) {
@@ -295,9 +305,16 @@ func isValidDirective(dir Directive) bool {
 }
 
 // Flush flushes any buffered XML to the underlying writer.
-// See the EncodeToken documentation for details about when it is necessary.
+// See the [Encoder.EncodeToken] documentation for details about when it is necessary.
 func (enc *Encoder) Flush() error {
-	return enc.p.Flush()
+	return enc.p.w.Flush()
+}
+
+// Close the Encoder, indicating that no more data will be written. It flushes
+// any buffered XML to the underlying writer and returns an error if the
+// written XML is invalid (e.g. by containing unclosed elements).
+func (enc *Encoder) Close() error {
+	return enc.p.Close()
 }
 
 // element represents a serialized XML element, in the form of either:
@@ -336,7 +353,7 @@ func joinPrefixed(prefix, name string) string {
 }
 
 type printer struct {
-	*bufio.Writer
+	w          *bufio.Writer
 	encoder    *Encoder
 	seq        int
 	indent     string
@@ -345,17 +362,19 @@ type printer struct {
 	indentedIn bool
 	putNewline bool
 	elements   []element
+	closed     bool
+	err        error
 }
 
 // getPrefix finds the prefix to use for the given namespace URI, but does not create it.
 func (p *printer) getPrefix(uri string) string {
 	switch uri {
 	case xmlURL:
-		// The "http://www.w3.org/XML/1998/namespace" name space is predefined as "xml"
+		// The "http://www.w3.org/XML/1998/namespace" namespace is predefined as "xml"
 		// and must be referred to that way.
 		return xmlPrefix
 	case xmlnsURL:
-		// (The "http://www.w3.org/2000/xmlns/" name space is also predefined as "xmlns",
+		// (The "http://www.w3.org/2000/xmlns/" namespace is also predefined as "xmlns",
 		// but users should not be trying to use that one directly - that's our job.)
 		return xmlnsPrefix
 	}
@@ -438,9 +457,9 @@ func (p *printer) writePrefixAttr(prefix, uri string) {
 }
 
 var (
-	marshalerType     = reflect.TypeOf((*Marshaler)(nil)).Elem()
-	marshalerAttrType = reflect.TypeOf((*MarshalerAttr)(nil)).Elem()
-	textMarshalerType = reflect.TypeOf((*encoding.TextMarshaler)(nil)).Elem()
+	marshalerType     = reflect.TypeFor[Marshaler]()
+	marshalerAttrType = reflect.TypeFor[MarshalerAttr]()
+	textMarshalerType = reflect.TypeFor[encoding.TextMarshaler]()
 )
 
 // marshalValue writes one or more XML elements representing val.
@@ -460,7 +479,7 @@ func (p *printer) marshalValue(val reflect.Value, finfo *fieldInfo, startTemplat
 	// Drill into interfaces and pointers.
 	// This can turn into an infinite loop given a cyclic chain,
 	// but it matches the Go 1 behavior.
-	for val.Kind() == reflect.Interface || val.Kind() == reflect.Ptr {
+	for val.Kind() == reflect.Interface || val.Kind() == reflect.Pointer {
 		if val.IsNil() {
 			return nil
 		}
@@ -555,7 +574,7 @@ func (p *printer) marshalValue(val reflect.Value, finfo *fieldInfo, startTemplat
 
 		fv := finfo.value(val, dontInitNilPointers)
 
-		if finfo.flags&fOmitEmpty != 0 && isEmptyValue(fv) {
+		if finfo.flags&fOmitEmpty != 0 && (!fv.IsValid() || isEmptyValue(fv)) {
 			continue
 		}
 
@@ -563,17 +582,17 @@ func (p *printer) marshalValue(val reflect.Value, finfo *fieldInfo, startTemplat
 			continue
 		}
 
-		name := Name{finfo.xmlns, joinPrefixed(finfo.prefix, finfo.name)}
+		name := Name{Space: finfo.xmlns, Local: joinPrefixed(finfo.prefix, finfo.name)}
 		if err := p.marshalAttr(&start, name, fv); err != nil {
 			return err
 		}
 	}
 
-	// If an xmlname was found, namespace must be overridden.
+	// If an empty name was found, namespace is overridden with an empty space
 	if tinfo.xmlname != nil && start.Name.Space == "" &&
+		tinfo.xmlname.xmlns == "" && tinfo.xmlname.name == "" &&
 		len(p.elements) != 0 && p.elements[len(p.elements)-1].xmlns != "" {
-		// Add attr xmlns="" to override the outer tag namespace
-		start.Attr = append(start.Attr, Attr{Name{"", xmlnsPrefix}, ""})
+		start.Attr = append(start.Attr, Attr{Name{Space: "", Local: xmlnsPrefix}, ""})
 	}
 
 	if err := p.writeStart(&start); err != nil {
@@ -653,7 +672,7 @@ func (p *printer) marshalAttr(start *StartElement, name Name, val reflect.Value)
 
 	// Dereference or skip nil pointer, interface values.
 	switch val.Kind() {
-	case reflect.Ptr, reflect.Interface:
+	case reflect.Pointer, reflect.Interface:
 		if val.IsNil() {
 			return nil
 		}
@@ -721,7 +740,7 @@ func (p *printer) marshalInterface(val Marshaler, start StartElement) error {
 		return err
 	}
 
-	// Make sure MarshalXML closed all its tags. p.tags[n-1] is the mark.
+	// Make sure MarshalXML closed all its tags. p.elements[n-1] is the mark.
 	if len(p.elements) > n {
 		return fmt.Errorf("xml: %s.MarshalXML wrote invalid XML: <%s> not closed", receiverType(val), p.elements[len(p.elements)-1].name)
 	}
@@ -899,7 +918,7 @@ func (p *printer) marshalSimple(typ reflect.Type, val reflect.Value) (string, []
 		// [...]byte
 		var bytes []byte
 		if val.CanAddr() {
-			bytes = val.Slice(0, val.Len()).Bytes()
+			bytes = val.Bytes()
 		} else {
 			bytes = make([]byte, val.Len())
 			reflect.Copy(reflect.ValueOf(bytes), val)
@@ -922,7 +941,7 @@ var ddBytes = []byte("--")
 // This can turn into an infinite loop given a cyclic chain,
 // but it matches the Go 1 behavior.
 func indirect(vf reflect.Value) reflect.Value {
-	for vf.Kind() == reflect.Interface || vf.Kind() == reflect.Ptr {
+	for vf.Kind() == reflect.Interface || vf.Kind() == reflect.Pointer {
 		if vf.IsNil() {
 			return vf
 		}
@@ -1071,7 +1090,7 @@ func (p *printer) marshalStruct(tinfo *typeInfo, val reflect.Value) error {
 				return err
 			}
 			if len(finfo.parents) > len(s.stack) {
-				if vf.Kind() != reflect.Ptr && vf.Kind() != reflect.Interface || !vf.IsNil() {
+				if vf.Kind() != reflect.Pointer && vf.Kind() != reflect.Interface || !vf.IsNil() {
 					if err := s.push(finfo.parents[len(s.stack):]); err != nil {
 						return err
 					}
@@ -1084,6 +1103,56 @@ func (p *printer) marshalStruct(tinfo *typeInfo, val reflect.Value) error {
 	}
 	s.trim(nil)
 	return p.cachedWriteError()
+}
+
+// Write implements io.Writer
+func (p *printer) Write(b []byte) (n int, err error) {
+	if p.closed && p.err == nil {
+		p.err = errors.New("use of closed Encoder")
+	}
+	if p.err == nil {
+		n, p.err = p.w.Write(b)
+	}
+	return n, p.err
+}
+
+// WriteString implements io.StringWriter
+func (p *printer) WriteString(s string) (n int, err error) {
+	if p.closed && p.err == nil {
+		p.err = errors.New("use of closed Encoder")
+	}
+	if p.err == nil {
+		n, p.err = p.w.WriteString(s)
+	}
+	return n, p.err
+}
+
+// WriteByte implements io.ByteWriter
+func (p *printer) WriteByte(c byte) error {
+	if p.closed && p.err == nil {
+		p.err = errors.New("use of closed Encoder")
+	}
+	if p.err == nil {
+		p.err = p.w.WriteByte(c)
+	}
+	return p.err
+}
+
+// Close the Encoder, indicating that no more data will be written. It flushes
+// any buffered XML to the underlying writer and returns an error if the
+// written XML is invalid (e.g. by containing unclosed elements).
+func (p *printer) Close() error {
+	if p.closed {
+		return nil
+	}
+	p.closed = true
+	if err := p.w.Flush(); err != nil {
+		return err
+	}
+	if len(p.elements) > 0 {
+		return fmt.Errorf("unclosed tag <%s>", p.elements[len(p.elements)-1].name)
+	}
+	return nil
 }
 
 // return the bufio Writer's cached write error
@@ -1158,7 +1227,7 @@ func (s *parentStack) push(parents []string) error {
 	return nil
 }
 
-// UnsupportedTypeError is returned when Marshal encounters a type
+// UnsupportedTypeError is returned when [Marshal] encounters a type
 // that cannot be converted into XML.
 type UnsupportedTypeError struct {
 	Type reflect.Type
@@ -1172,16 +1241,12 @@ func isEmptyValue(v reflect.Value) bool {
 	switch v.Kind() {
 	case reflect.Array, reflect.Map, reflect.Slice, reflect.String:
 		return v.Len() == 0
-	case reflect.Bool:
-		return !v.Bool()
-	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-		return v.Int() == 0
-	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
-		return v.Uint() == 0
-	case reflect.Float32, reflect.Float64:
-		return v.Float() == 0
-	case reflect.Interface, reflect.Ptr:
-		return v.IsNil()
+	case reflect.Bool,
+		reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
+		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr,
+		reflect.Float32, reflect.Float64,
+		reflect.Interface, reflect.Pointer:
+		return v.IsZero()
 	}
 	return false
 }

--- a/xml/marshal_test.go
+++ b/xml/marshal_test.go
@@ -120,17 +120,17 @@ type MixedNested struct {
 }
 
 type NilTest struct {
-	A interface{} `xml:"parent1>parent2>a"`
-	B interface{} `xml:"parent1>b"`
-	C interface{} `xml:"parent1>parent2>c"`
+	A any `xml:"parent1>parent2>a"`
+	B any `xml:"parent1>b"`
+	C any `xml:"parent1>parent2>c"`
 }
 
 type Service struct {
 	XMLName struct{} `xml:"service"`
 	Domain  *Domain  `xml:"host>domain"`
 	Port    *Port    `xml:"host>port"`
-	Extra1  interface{}
-	Extra2  interface{} `xml:"host>extra2"`
+	Extra1  any
+	Extra2  any `xml:"host>extra2"`
 }
 
 var nilStruct *Ship
@@ -283,7 +283,7 @@ type Data struct {
 }
 
 type Plain struct {
-	V interface{}
+	V any
 }
 
 type MyInt int
@@ -387,7 +387,7 @@ type NestedAndCData struct {
 	CDATA string   `xml:",cdata"`
 }
 
-func ifaceptr(x interface{}) interface{} {
+func ifaceptr(x any) any {
 	return &x
 }
 
@@ -412,7 +412,7 @@ type DirectComment struct {
 
 type IfaceComment struct {
 	T1      T1
-	Comment interface{} `xml:",comment"`
+	Comment any `xml:",comment"`
 	T2      T2
 }
 
@@ -430,7 +430,7 @@ type DirectChardata struct {
 
 type IfaceChardata struct {
 	T1       T1
-	Chardata interface{} `xml:",chardata"`
+	Chardata any `xml:",chardata"`
 	T2       T2
 }
 
@@ -448,7 +448,7 @@ type DirectCDATA struct {
 
 type IfaceCDATA struct {
 	T1    T1
-	CDATA interface{} `xml:",cdata"`
+	CDATA any `xml:",cdata"`
 	T2    T2
 }
 
@@ -466,7 +466,7 @@ type DirectInnerXML struct {
 
 type IfaceInnerXML struct {
 	T1       T1
-	InnerXML interface{} `xml:",innerxml"`
+	InnerXML any `xml:",innerxml"`
 	T2       T2
 }
 
@@ -484,7 +484,7 @@ type DirectElement struct {
 
 type IfaceElement struct {
 	T1      T1
-	Element interface{}
+	Element any
 	T2      T2
 }
 
@@ -502,7 +502,7 @@ type DirectOmitEmpty struct {
 
 type IfaceOmitEmpty struct {
 	T1        T1
-	OmitEmpty interface{} `xml:",omitempty"`
+	OmitEmpty any `xml:",omitempty"`
 	T2        T2
 }
 
@@ -520,8 +520,12 @@ type DirectAny struct {
 
 type IfaceAny struct {
 	T1  T1
-	Any interface{} `xml:",any"`
+	Any any `xml:",any"`
 	T2  T2
+}
+
+type Generic[T any] struct {
+	X T
 }
 
 type EPP struct {
@@ -568,7 +572,7 @@ var (
 // please try to make them two-way as well to ensure that
 // marshaling and unmarshaling are as symmetrical as feasible.
 var marshalTests = []struct {
-	Value          interface{}
+	Value          any
 	ExpectXML      string
 	MarshalOnly    bool
 	MarshalError   string
@@ -661,7 +665,7 @@ var marshalTests = []struct {
 	{Value: &Port{Type: "ssl", Number: "443"}, ExpectXML: `<port type="ssl">443</port>`},
 	{Value: &Port{Number: "443"}, ExpectXML: `<port>443</port>`},
 	{Value: &Port{Type: "<unix>"}, ExpectXML: `<port type="&lt;unix&gt;"></port>`},
-	// Marshal is not symetric to Unmarshal for these oddities because &apos is written as &#39
+	// Marshal is not symmetric to Unmarshal for these oddities because &apos is written as &#39
 	{Value: &Port{Type: "<un'ix>"}, ExpectXML: `<port type="&lt;un&apos;ix&gt;"></port>`, UnmarshalOnly: true},
 	{Value: &Port{Type: "<un\"ix>"}, ExpectXML: `<port type="&lt;un&quot;ix&gt;"></port>`, UnmarshalOnly: true},
 	{Value: &Port{Type: "<un&ix>"}, ExpectXML: `<port type="&lt;un&amp;ix&gt;"></port>`},
@@ -678,6 +682,7 @@ var marshalTests = []struct {
 	{Value: &Particle{HasMass: true}, ExpectXML: `<particle>true</particle>`},
 	{Value: &Departure{When: ParseTime("2013-01-09T00:15:00-09:00")}, ExpectXML: `<departure>2013-01-09T00:15:00-09:00</departure>`},
 	{Value: atomValue, ExpectXML: atomXML},
+	{Value: &Generic[int]{1}, ExpectXML: `<Generic><X>1</X></Generic>`},
 	{
 		Value: &Ship{
 			Name:  "Heart of Gold",
@@ -1789,7 +1794,7 @@ type BadAttr struct {
 }
 
 var marshalErrorTests = []struct {
-	Value interface{}
+	Value any
 	Err   string
 	Kind  reflect.Kind
 }{
@@ -1827,7 +1832,7 @@ var marshalErrorTests = []struct {
 }
 
 var marshalIndentTests = []struct {
-	Value     interface{}
+	Value     any
 	Prefix    string
 	Indent    string
 	ExpectXML string
@@ -1840,7 +1845,7 @@ var marshalIndentTests = []struct {
 		},
 		Prefix:    "",
 		Indent:    "\t",
-		ExpectXML: fmt.Sprintf("<agent handle=\"007\">\n\t<Identity>James Bond</Identity><redacted/>\n</agent>"),
+		ExpectXML: "<agent handle=\"007\">\n\t<Identity>James Bond</Identity><redacted/>\n</agent>",
 	},
 }
 
@@ -1983,13 +1988,13 @@ func TestMarshalWriteIOErrors(t *testing.T) {
 }
 
 func TestMarshalFlush(t *testing.T) {
-	var buf bytes.Buffer
+	var buf strings.Builder
 	enc := NewEncoder(&buf)
 	if err := enc.EncodeToken(CharData("hello world")); err != nil {
 		t.Fatalf("enc.EncodeToken: %v", err)
 	}
 	if buf.Len() > 0 {
-		t.Fatalf("enc.EncodeToken caused actual write: %q", buf.Bytes())
+		t.Fatalf("enc.EncodeToken caused actual write: %q", buf.String())
 	}
 	if err := enc.Flush(); err != nil {
 		t.Fatalf("enc.Flush: %v", err)
@@ -2022,7 +2027,7 @@ func BenchmarkUnmarshal(b *testing.B) {
 func TestStructPointerMarshal(t *testing.T) {
 	type A struct {
 		XMLName string `xml:"a"`
-		B       []interface{}
+		B       []any
 	}
 	type C struct {
 		XMLName Name
@@ -2582,7 +2587,7 @@ var encodeTokenTests = []struct {
 func TestEncodeToken(t *testing.T) {
 loop:
 	for i, tt := range encodeTokenTests {
-		var buf bytes.Buffer
+		var buf strings.Builder
 		enc := NewEncoder(&buf)
 		var err error
 		for j, tok := range tt.toks {
@@ -2592,8 +2597,8 @@ loop:
 				continue loop
 			}
 		}
-		errorf := func(f string, a ...interface{}) {
-			t.Errorf("#%d %s; token #%d:%s", i, tt.desc, len(tt.toks)-1, fmt.Sprintf(f, a...))
+		errorf := func(f string, a ...any) {
+			t.Errorf("#%d %s token #%d:%s", i, tt.desc, len(tt.toks)-1, fmt.Sprintf(f, a...))
 		}
 		switch {
 		case tt.err != "" && err == nil:
@@ -2702,7 +2707,7 @@ func TestIsValidDirective(t *testing.T) {
 
 // Issue 11719. EncodeToken used to silently eat tokens with an invalid type.
 func TestSimpleUseOfEncodeToken(t *testing.T) {
-	var buf bytes.Buffer
+	var buf strings.Builder
 	enc := NewEncoder(&buf)
 	if err := enc.EncodeToken(&StartElement{Name: Name{"", "object1"}}); err == nil {
 		t.Errorf("enc.EncodeToken: pointer type should be rejected")
@@ -2758,5 +2763,99 @@ func TestInvalidXMLName(t *testing.T) {
 		t.Error("unexpected success")
 	} else if want := "invalid tag"; !strings.Contains(err.Error(), want) {
 		t.Errorf("error %q does not contain %q", err, want)
+	}
+}
+
+// Issue 50164. Crash on zero value XML attribute.
+type LayerOne struct {
+	XMLName Name `xml:"l1"`
+
+	Value     *float64 `xml:"value,omitempty"`
+	*LayerTwo `xml:",omitempty"`
+}
+
+type LayerTwo struct {
+	ValueTwo *int `xml:"value_two,attr,omitempty"`
+}
+
+func TestMarshalZeroValue(t *testing.T) {
+	proofXml := `<l1><value>1.2345</value></l1>`
+	var l1 LayerOne
+	err := Unmarshal([]byte(proofXml), &l1)
+	if err != nil {
+		t.Fatalf("unmarshal XML error: %v", err)
+	}
+	want := float64(1.2345)
+	got := *l1.Value
+	if got != want {
+		t.Fatalf("unexpected unmarshal result, want %f but got %f", want, got)
+	}
+
+	// Marshal again (or Encode again)
+	// In issue 50164, here `Marshal(l1)` will panic because of the zero value of xml attribute ValueTwo `value_two`.
+	anotherXML, err := Marshal(l1)
+	if err != nil {
+		t.Fatalf("marshal XML error: %v", err)
+	}
+	if string(anotherXML) != proofXml {
+		t.Fatalf("unexpected unmarshal result, want %q but got %q", proofXml, anotherXML)
+	}
+}
+
+var closeTests = []struct {
+	desc string
+	toks []Token
+	want string
+	err  string
+}{{
+	desc: "unclosed start element",
+	toks: []Token{
+		StartElement{Name{"", "foo"}, nil},
+	},
+	want: `<foo>`,
+	err:  "unclosed tag <foo>",
+}, {
+	desc: "closed element",
+	toks: []Token{
+		StartElement{Name{"", "foo"}, nil},
+		EndElement{Name{"", "foo"}},
+	},
+	want: `<foo></foo>`,
+}, {
+	desc: "directive",
+	toks: []Token{
+		Directive("foo"),
+	},
+	want: `<!foo>`,
+}}
+
+func TestClose(t *testing.T) {
+	for _, tt := range closeTests {
+		tt := tt
+		t.Run(tt.desc, func(t *testing.T) {
+			var out strings.Builder
+			enc := NewEncoder(&out)
+			for j, tok := range tt.toks {
+				if err := enc.EncodeToken(tok); err != nil {
+					t.Fatalf("token #%d: %v", j, err)
+				}
+			}
+			err := enc.Close()
+			switch {
+			case tt.err != "" && err == nil:
+				t.Error(" expected error; got none")
+			case tt.err == "" && err != nil:
+				t.Errorf(" got error: %v", err)
+			case tt.err != "" && err != nil && tt.err != err.Error():
+				t.Errorf(" error mismatch; got %v, want %v", err, tt.err)
+			}
+			if got := out.String(); got != tt.want {
+				t.Errorf("\ngot  %v\nwant %v", got, tt.want)
+			}
+			t.Log(enc.p.closed)
+			if err := enc.EncodeToken(Directive("foo")); err == nil {
+				t.Errorf("unexpected success when encoding after Close")
+			}
+		})
 	}
 }

--- a/xml/read.go
+++ b/xml/read.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"runtime"
 	"strconv"
 	"strings"
 )
@@ -18,7 +19,7 @@ import (
 // an XML element is an order-dependent collection of anonymous
 // values, while a data structure is an order-independent collection
 // of named values.
-// See package json for a textual representation more suitable
+// See [encoding/json] for a textual representation more suitable
 // to data structures.
 
 // Unmarshal parses the XML-encoded data and stores the result in
@@ -35,67 +36,71 @@ import (
 // In the rules, the tag of a field refers to the value associated with the
 // key 'xml' in the struct field's tag (see the example above).
 //
-//   * If the struct has a field of type []byte or string with tag
-//      ",innerxml", Unmarshal accumulates the raw XML nested inside the
-//      element in that field. The rest of the rules still apply.
+//   - If the struct has a field of type []byte or string with tag
+//     ",innerxml", Unmarshal accumulates the raw XML nested inside the
+//     element in that field. The rest of the rules still apply.
 //
-//   * If the struct has a field named XMLName of type Name,
-//      Unmarshal records the element name in that field.
+//   - If the struct has a field named XMLName of type Name,
+//     Unmarshal records the element name in that field.
 //
-//   * If the XMLName field has an associated tag of the form
-//      "name" or "namespace-URL name", the XML element must have
-//      the given name (and, optionally, name space) or else Unmarshal
-//      returns an error.
+//   - If the XMLName field has an associated tag of the form
+//     "name" or "namespace-URL name", the XML element must have
+//     the given name (and, optionally, namespace) or else Unmarshal
+//     returns an error.
 //
-//   * If the XML element has an attribute whose name matches a
-//      struct field name with an associated tag containing ",attr" or
-//      the explicit name in a struct field tag of the form "name,attr",
-//      Unmarshal records the attribute value in that field.
+//   - If the XMLName field contains an XML namespace, it may also
+//     optionally specify a namespace prefix in the form of
+//     "namespace-URL prefix:name".
 //
-//   * If the XML element has an attribute not handled by the previous
-//      rule and the struct has a field with an associated tag containing
-//      ",any,attr", Unmarshal records the attribute value in the first
-//      such field.
+//   - If the XML element has an attribute whose name matches a
+//     struct field name with an associated tag containing ",attr" or
+//     the explicit name in a struct field tag of the form "name,attr",
+//     Unmarshal records the attribute value in that field.
 //
-//   * If the XML element contains character data, that data is
-//      accumulated in the first struct field that has tag ",chardata".
-//      The struct field may have type []byte or string.
-//      If there is no such field, the character data is discarded.
+//   - If the XML element has an attribute not handled by the previous
+//     rule and the struct has a field with an associated tag containing
+//     ",any,attr", Unmarshal records the attribute value in the first
+//     such field.
 //
-//   * If the XML element contains comments, they are accumulated in
-//      the first struct field that has tag ",comment".  The struct
-//      field may have type []byte or string. If there is no such
-//      field, the comments are discarded.
+//   - If the XML element contains character data, that data is
+//     accumulated in the first struct field that has tag ",chardata".
+//     The struct field may have type []byte or string.
+//     If there is no such field, the character data is discarded.
 //
-//   * If the XML element contains a sub-element whose name matches
-//      the prefix of a tag formatted as "a" or "a>b>c", unmarshal
-//      will descend into the XML structure looking for elements with the
-//      given names, and will map the innermost elements to that struct
-//      field. A tag starting with ">" is equivalent to one starting
-//      with the field name followed by ">".
+//   - If the XML element contains comments, they are accumulated in
+//     the first struct field that has tag ",comment".  The struct
+//     field may have type []byte or string. If there is no such
+//     field, the comments are discarded.
 //
-//   * If the XML element contains a sub-element whose name matches
-//      a struct field's XMLName tag and the struct field has no
-//      explicit name tag as per the previous rule, unmarshal maps
-//      the sub-element to that struct field.
+//   - If the XML element contains a sub-element whose name matches
+//     the prefix of a tag formatted as "a" or "a>b>c", unmarshal
+//     will descend into the XML structure looking for elements with the
+//     given names, and will map the innermost elements to that struct
+//     field. A tag starting with ">" is equivalent to one starting
+//     with the field name followed by ">".
 //
-//   * If the XML element contains a sub-element whose name matches a
-//      field without any mode flags (",attr", ",chardata", etc), Unmarshal
-//      maps the sub-element to that struct field.
+//   - If the XML element contains a sub-element whose name matches
+//     a struct field's XMLName tag and the struct field has no
+//     explicit name tag as per the previous rule, unmarshal maps
+//     the sub-element to that struct field.
 //
-//   * If the XML element contains a sub-element that hasn't matched any
-//      of the above rules and the struct has a field with tag ",any",
-//      unmarshal maps the sub-element to that struct field.
+//   - If the XML element contains a sub-element whose name matches a
+//     field without any mode flags (",attr", ",chardata", etc), Unmarshal
+//     maps the sub-element to that struct field.
 //
-//   * An anonymous struct field is handled as if the fields of its
-//      value were part of the outer struct.
+//   - If the XML element contains a sub-element that hasn't matched any
+//     of the above rules and the struct has a field with tag ",any",
+//     unmarshal maps the sub-element to that struct field.
 //
-//   * A struct field with tag "-" is never unmarshaled into.
+//   - An anonymous struct field is handled as if the fields of its
+//     value were part of the outer struct.
+//
+//   - A struct field with tag "-" is never unmarshaled into.
 //
 // If Unmarshal encounters a field type that implements the Unmarshaler
 // interface, Unmarshal calls its UnmarshalXML method to produce the value from
 // the XML element.  Otherwise, if the value implements
-// encoding.TextUnmarshaler, Unmarshal calls that value's UnmarshalText method.
+// [encoding.TextUnmarshaler], Unmarshal calls that value's UnmarshalText method.
 //
 // Unmarshal maps an XML element to a string or []byte by saving the
 // concatenation of that element's character data in the string or
@@ -104,7 +109,7 @@ import (
 // Unmarshal maps an attribute value to a string or []byte by saving
 // the value in the string or slice.
 //
-// Unmarshal maps an attribute value to an Attr by saving the attribute,
+// Unmarshal maps an attribute value to an [Attr] by saving the attribute,
 // including its name, in the Attr.
 //
 // Unmarshal maps an XML element or attribute value to a slice by
@@ -129,26 +134,30 @@ import (
 // A missing element or empty attribute value will be unmarshaled as a zero value.
 // If the field is a slice, a zero value will be appended to the field. Otherwise, the
 // field will be set to its zero value.
-func Unmarshal(data []byte, v interface{}) error {
+func Unmarshal(data []byte, v any) error {
 	return NewDecoder(bytes.NewReader(data)).Decode(v)
 }
 
-// Decode works like Unmarshal, except it reads the decoder
+// Decode works like [Unmarshal], except it reads the decoder
 // stream to find the start element.
-func (d *Decoder) Decode(v interface{}) error {
+func (d *Decoder) Decode(v any) error {
 	return d.DecodeElement(v, nil)
 }
 
-// DecodeElement works like Unmarshal except that it takes
+// DecodeElement works like [Unmarshal] except that it takes
 // a pointer to the start XML element to decode into v.
 // It is useful when a client reads some raw XML tokens itself
-// but also wants to defer to Unmarshal for some elements.
-func (d *Decoder) DecodeElement(v interface{}, start *StartElement) error {
+// but also wants to defer to [Unmarshal] for some elements.
+func (d *Decoder) DecodeElement(v any, start *StartElement) error {
 	val := reflect.ValueOf(v)
-	if val.Kind() != reflect.Ptr {
+	if val.Kind() != reflect.Pointer {
 		return errors.New("non-pointer passed to Unmarshal")
 	}
-	return d.unmarshal(val.Elem(), start)
+
+	if val.IsNil() {
+		return errors.New("nil pointer passed to Unmarshal")
+	}
+	return d.unmarshal(val.Elem(), start, 0)
 }
 
 // An UnmarshalError represents an error in the unmarshaling process.
@@ -179,7 +188,7 @@ type Unmarshaler interface {
 // an XML attribute description of themselves.
 //
 // UnmarshalXMLAttr decodes a single XML attribute.
-// If it returns an error, the outer call to Unmarshal stops and
+// If it returns an error, the outer call to [Unmarshal] stops and
 // returns that error.
 // UnmarshalXMLAttr is used only for struct fields with the
 // "attr" option in the field tag.
@@ -188,7 +197,7 @@ type UnmarshalerAttr interface {
 }
 
 // receiverType returns the receiver type to use in an expression like "%s.MethodName".
-func receiverType(val interface{}) string {
+func receiverType(val any) string {
 	t := reflect.TypeOf(val)
 	if t.Name() != "" {
 		return t.String()
@@ -244,7 +253,7 @@ func (d *Decoder) unmarshalTextInterface(val encoding.TextUnmarshaler) error {
 
 // unmarshalAttr unmarshals a single XML attribute into val.
 func (d *Decoder) unmarshalAttr(val reflect.Value, attr Attr) error {
-	if val.Kind() == reflect.Ptr {
+	if val.Kind() == reflect.Pointer {
 		if val.IsNil() {
 			val.Set(reflect.New(val.Type().Elem()))
 		}
@@ -279,7 +288,8 @@ func (d *Decoder) unmarshalAttr(val reflect.Value, attr Attr) error {
 		// Slice of element values.
 		// Grow slice.
 		n := val.Len()
-		val.Set(reflect.Append(val, reflect.Zero(val.Type().Elem())))
+		val.Grow(1)
+		val.SetLen(n + 1)
 
 		// Recur to read element into slice.
 		if err := d.unmarshalAttr(val.Index(n), attr); err != nil {
@@ -298,14 +308,24 @@ func (d *Decoder) unmarshalAttr(val reflect.Value, attr Attr) error {
 }
 
 var (
-	attrType            = reflect.TypeOf(Attr{})
-	unmarshalerType     = reflect.TypeOf((*Unmarshaler)(nil)).Elem()
-	unmarshalerAttrType = reflect.TypeOf((*UnmarshalerAttr)(nil)).Elem()
-	textUnmarshalerType = reflect.TypeOf((*encoding.TextUnmarshaler)(nil)).Elem()
+	attrType            = reflect.TypeFor[Attr]()
+	unmarshalerType     = reflect.TypeFor[Unmarshaler]()
+	unmarshalerAttrType = reflect.TypeFor[UnmarshalerAttr]()
+	textUnmarshalerType = reflect.TypeFor[encoding.TextUnmarshaler]()
 )
 
+const (
+	maxUnmarshalDepth     = 10000
+	maxUnmarshalDepthWasm = 5000 // go.dev/issue/56498
+)
+
+var errUnmarshalDepth = errors.New("exceeded max depth")
+
 // Unmarshal a single XML element into val.
-func (d *Decoder) unmarshal(val reflect.Value, start *StartElement) error {
+func (d *Decoder) unmarshal(val reflect.Value, start *StartElement, depth int) error {
+	if depth >= maxUnmarshalDepth || runtime.GOARCH == "wasm" && depth >= maxUnmarshalDepthWasm {
+		return errUnmarshalDepth
+	}
 	// Find start element if we need it.
 	if start == nil {
 		for {
@@ -324,12 +344,12 @@ func (d *Decoder) unmarshal(val reflect.Value, start *StartElement) error {
 	// usefully addressable.
 	if val.Kind() == reflect.Interface && !val.IsNil() {
 		e := val.Elem()
-		if e.Kind() == reflect.Ptr && !e.IsNil() {
+		if e.Kind() == reflect.Pointer && !e.IsNil() {
 			val = e
 		}
 	}
 
-	if val.Kind() == reflect.Ptr {
+	if val.Kind() == reflect.Pointer {
 		if val.IsNil() {
 			val.Set(reflect.New(val.Type().Elem()))
 		}
@@ -395,10 +415,11 @@ func (d *Decoder) unmarshal(val reflect.Value, start *StartElement) error {
 		// Slice of element values.
 		// Grow slice.
 		n := v.Len()
-		v.Set(reflect.Append(val, reflect.Zero(v.Type().Elem())))
+		v.Grow(1)
+		v.SetLen(n + 1)
 
 		// Recur to read element into slice.
-		if err := d.unmarshal(v.Index(n), start); err != nil {
+		if err := d.unmarshal(v.Index(n), start, depth+1); err != nil {
 			v.SetLen(n)
 			return err
 		}
@@ -427,9 +448,9 @@ func (d *Decoder) unmarshal(val reflect.Value, start *StartElement) error {
 				return UnmarshalError("expected element type <" + finfo.name + "> but have <" + start.Name.Local + ">")
 			}
 			if finfo.xmlns != "" && finfo.xmlns != start.Name.Space {
-				e := "expected element <" + finfo.name + "> in name space " + finfo.xmlns + " but have "
+				e := "expected element <" + finfo.name + "> in namespace " + finfo.xmlns + " but have "
 				if start.Name.Space == "" {
-					e += "no name space"
+					e += "no namespace"
 				} else {
 					e += start.Name.Space
 				}
@@ -535,13 +556,15 @@ Loop:
 		case StartElement:
 			consumed := false
 			if sv.IsValid() {
-				consumed, err = d.unmarshalPath(tinfo, sv, nil, &t)
+				// unmarshalPath can call unmarshal, so we need to pass the depth through so that
+				// we can continue to enforce the maximum recursion limit.
+				consumed, err = d.unmarshalPath(tinfo, sv, nil, &t, depth)
 				if err != nil {
 					return err
 				}
 				if !consumed && saveAny.IsValid() {
 					consumed = true
-					if err := d.unmarshal(saveAny, &t); err != nil {
+					if err := d.unmarshal(saveAny, &t, depth+1); err != nil {
 						return err
 					}
 				}
@@ -616,7 +639,7 @@ Loop:
 func copyValue(dst reflect.Value, src []byte) (err error) {
 	dst0 := dst
 
-	if dst.Kind() == reflect.Ptr {
+	if dst.Kind() == reflect.Pointer {
 		if dst.IsNil() {
 			dst.Set(reflect.New(dst.Type().Elem()))
 		}
@@ -686,7 +709,7 @@ func copyValue(dst reflect.Value, src []byte) (err error) {
 // The consumed result tells whether XML elements have been consumed
 // from the Decoder until start's matching end element, or if it's
 // still untouched because start is uninteresting for sv's fields.
-func (d *Decoder) unmarshalPath(tinfo *typeInfo, sv reflect.Value, parents []string, start *StartElement) (consumed bool, err error) {
+func (d *Decoder) unmarshalPath(tinfo *typeInfo, sv reflect.Value, parents []string, start *StartElement, depth int) (consumed bool, err error) {
 	recurse := false
 Loop:
 	for i := range tinfo.fields {
@@ -701,7 +724,7 @@ Loop:
 		}
 		if len(finfo.parents) == len(parents) && finfo.name == start.Name.Local {
 			// It's a perfect match, unmarshal the field.
-			return true, d.unmarshal(finfo.value(sv, initNilPointers), start)
+			return true, d.unmarshal(finfo.value(sv, initNilPointers), start, depth+1)
 		}
 		if len(finfo.parents) > len(parents) && finfo.parents[len(parents)] == start.Name.Local {
 			// It's a prefix for the field. Break and recurse
@@ -730,7 +753,9 @@ Loop:
 		}
 		switch t := tok.(type) {
 		case StartElement:
-			consumed2, err := d.unmarshalPath(tinfo, sv, parents, &t)
+			// the recursion depth of unmarshalPath is limited to the path length specified
+			// by the struct field tag, so we don't increment the depth here.
+			consumed2, err := d.unmarshalPath(tinfo, sv, parents, &t, depth)
 			if err != nil {
 				return true, err
 			}
@@ -746,12 +771,12 @@ Loop:
 }
 
 // Skip reads tokens until it has consumed the end element
-// matching the most recent start element already consumed.
-// It recurs if it encounters a start element, so it can be used to
-// skip nested structures.
+// matching the most recent start element already consumed,
+// skipping nested structures.
 // It returns nil if it finds an end element matching the start
 // element; otherwise it returns an error describing the problem.
 func (d *Decoder) Skip() error {
+	var depth int64
 	for {
 		tok, err := d.Token()
 		if err != nil {
@@ -759,11 +784,12 @@ func (d *Decoder) Skip() error {
 		}
 		switch tok.(type) {
 		case StartElement:
-			if err := d.Skip(); err != nil {
-				return err
-			}
+			depth++
 		case EndElement:
-			return nil
+			if depth == 0 {
+				return nil
+			}
+			depth--
 		}
 	}
 }

--- a/xml/read_test.go
+++ b/xml/read_test.go
@@ -5,8 +5,11 @@
 package xml
 
 import (
+	"bytes"
+	"errors"
 	"io"
 	"reflect"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -270,7 +273,7 @@ type PathTestE struct {
 	Before, After string
 }
 
-var pathTests = []interface{}{
+var pathTests = []any{
 	&PathTestA{Items: []PathTestItem{{"A"}, {"D"}}, Before: "1", After: "2"},
 	&PathTestB{Other: []PathTestItem{{"A"}, {"D"}}, Before: "1", After: "2"},
 	&PathTestC{Values1: []string{"A", "C", "D"}, Values2: []string{"B"}, Before: "1", After: "2"},
@@ -321,12 +324,12 @@ type BadPathEmbeddedB struct {
 }
 
 var badPathTests = []struct {
-	v, e interface{}
+	v, e any
 }{
-	{&BadPathTestA{}, &TagPathError{reflect.TypeOf(BadPathTestA{}), "First", "items>item1", "Second", "items"}},
-	{&BadPathTestB{}, &TagPathError{reflect.TypeOf(BadPathTestB{}), "First", "items>item1", "Second", "items>item1>value"}},
-	{&BadPathTestC{}, &TagPathError{reflect.TypeOf(BadPathTestC{}), "First", "", "Second", "First"}},
-	{&BadPathTestD{}, &TagPathError{reflect.TypeOf(BadPathTestD{}), "First", "", "Second", "First"}},
+	{&BadPathTestA{}, &TagPathError{reflect.TypeFor[BadPathTestA](), "First", "items>item1", "Second", "items"}},
+	{&BadPathTestB{}, &TagPathError{reflect.TypeFor[BadPathTestB](), "First", "items>item1", "Second", "items>item1>value"}},
+	{&BadPathTestC{}, &TagPathError{reflect.TypeFor[BadPathTestC](), "First", "", "Second", "First"}},
+	{&BadPathTestD{}, &TagPathError{reflect.TypeFor[BadPathTestD](), "First", "", "Second", "First"}},
 }
 
 func TestUnmarshalBadPaths(t *testing.T) {
@@ -535,14 +538,14 @@ var tableAttrs = []struct {
 		tab: TableAttrs{TAttr{HTable: "hello", FTable: "world"}},
 	},
 	{
-		// Default space does not apply to attribute names.
+		// Default namespace does not apply to attribute names.
 		xml: `<TableAttrs xmlns="http://www.w3schools.com/furniture" xmlns:h="http://www.w3.org/TR/html4/"><TAttr ` +
 			`h:table="hello" table="world" ` +
 			`/></TableAttrs>`,
 		tab: TableAttrs{TAttr{HTable: "hello", FTable: ""}},
 	},
 	{
-		// Default space does not apply to attribute names.
+		// Default namespace does not apply to attribute names.
 		xml: `<TableAttrs xmlns:f="http://www.w3schools.com/furniture"><TAttr xmlns="http://www.w3.org/TR/html4/" ` +
 			`table="hello" f:table="world" ` +
 			`/></TableAttrs>`,
@@ -555,7 +558,7 @@ var tableAttrs = []struct {
 		tab: TableAttrs{},
 	},
 	{
-		// Default space does not apply to attribute names.
+		// Default namespace does not apply to attribute names.
 		xml: `<TableAttrs xmlns:h="http://www.w3.org/TR/html4/"><TAttr ` +
 			`h:table="hello" table="world" ` +
 			`/></TableAttrs>`,
@@ -563,7 +566,7 @@ var tableAttrs = []struct {
 		ns:  "http://www.w3schools.com/furniture",
 	},
 	{
-		// Default space does not apply to attribute names.
+		// Default namespace does not apply to attribute names.
 		xml: `<TableAttrs xmlns:f="http://www.w3schools.com/furniture"><TAttr ` +
 			`table="hello" f:table="world" ` +
 			`/></TableAttrs>`,
@@ -691,7 +694,7 @@ type Pea struct {
 }
 
 type Pod struct {
-	Pea interface{} `xml:"Pea"`
+	Pea any `xml:"Pea"`
 }
 
 // https://golang.org/issue/6836
@@ -1078,4 +1081,48 @@ func TestUnmarshalWhitespaceAttrs(t *testing.T) {
 	if v != want {
 		t.Fatalf("whitespace attrs: Unmarshal:\nhave: %#+v\nwant: %#+v", v, want)
 	}
+}
+
+// golang.org/issues/53350
+func TestUnmarshalIntoNil(t *testing.T) {
+	type T struct {
+		A int `xml:"A"`
+	}
+
+	var nilPointer *T
+	err := Unmarshal([]byte("<T><A>1</A></T>"), nilPointer)
+
+	if err == nil {
+		t.Fatalf("no error in unmarshaling")
+	}
+
+}
+
+func TestCVE202228131(t *testing.T) {
+	type nested struct {
+		Parent *nested `xml:",any"`
+	}
+	var n nested
+	err := Unmarshal(bytes.Repeat([]byte("<a>"), maxUnmarshalDepth+1), &n)
+	if err == nil {
+		t.Fatal("Unmarshal did not fail")
+	} else if !errors.Is(err, errUnmarshalDepth) {
+		t.Fatalf("Unmarshal unexpected error: got %q, want %q", err, errUnmarshalDepth)
+	}
+}
+
+func TestCVE202230633(t *testing.T) {
+	if testing.Short() || runtime.GOARCH == "wasm" {
+		t.Skip("test requires significant memory")
+	}
+	defer func() {
+		p := recover()
+		if p != nil {
+			t.Fatal("Unmarshal panicked")
+		}
+	}()
+	var example struct {
+		Things []string
+	}
+	Unmarshal(bytes.Repeat([]byte("<a>"), 17_000_000), &example)
 }

--- a/xml/typeinfo.go
+++ b/xml/typeinfo.go
@@ -47,7 +47,7 @@ const (
 
 var tinfoMap sync.Map // map[reflect.Type]*typeInfo
 
-var nameType = reflect.TypeOf(Name{})
+var nameType = reflect.TypeFor[Name]()
 
 // getTypeInfo returns the typeInfo structure with details necessary
 // for marshaling and unmarshaling typ.
@@ -68,7 +68,7 @@ func getTypeInfo(typ reflect.Type) (*typeInfo, error) {
 			// For embedded structs, embed its fields.
 			if f.Anonymous { // i.e. reflect package will panic to get a Value
 				t := f.Type
-				if t.Kind() == reflect.Ptr {
+				if t.Kind() == reflect.Pointer {
 					t = t.Elem()
 				}
 				if t.Kind() == reflect.Struct {
@@ -114,8 +114,8 @@ func structFieldInfo(typ reflect.Type, f *reflect.StructField) (*fieldInfo, erro
 
 	// Split the tag from the xml namespace if necessary.
 	tag := f.Tag.Get("xml")
-	if i := strings.Index(tag, " "); i >= 0 {
-		finfo.xmlns, tag = tag[:i], tag[i+1:]
+	if ns, t, ok := strings.Cut(tag, " "); ok {
+		finfo.xmlns, tag = ns, t
 	}
 
 	// Parse flags.
@@ -233,7 +233,7 @@ func structFieldInfo(typ reflect.Type, f *reflect.StructField) (*fieldInfo, erro
 // in case it exists and has a valid xml field tag, otherwise
 // it returns nil.
 func lookupXMLName(typ reflect.Type) (xmlname *fieldInfo) {
-	for typ.Kind() == reflect.Ptr {
+	for typ.Kind() == reflect.Pointer {
 		typ = typ.Elem()
 	}
 	if typ.Kind() != reflect.Struct {
@@ -253,13 +253,6 @@ func lookupXMLName(typ reflect.Type) (xmlname *fieldInfo) {
 		break
 	}
 	return nil
-}
-
-func min(a, b int) int {
-	if a <= b {
-		return a
-	}
-	return b
 }
 
 // addFieldInfo adds finfo to tinfo.fields if there are no
@@ -297,7 +290,6 @@ Loop:
 			}
 		} else {
 			if newf.name == oldf.name && newf.xmlns == oldf.xmlns {
-				// A conflict is only if the names are identical in the same namespace which might be ""
 				conflicts = append(conflicts, i)
 			}
 		}
@@ -363,7 +355,7 @@ func (finfo *fieldInfo) value(v reflect.Value, shouldInitNilPointers bool) refle
 	for i, x := range finfo.idx {
 		if i > 0 {
 			t := v.Type()
-			if t.Kind() == reflect.Ptr && t.Elem().Kind() == reflect.Struct {
+			if t.Kind() == reflect.Pointer && t.Elem().Kind() == reflect.Struct {
 				if v.IsNil() {
 					if !shouldInitNilPointers {
 						return reflect.Value{}

--- a/xml/xml.go
+++ b/xml/xml.go
@@ -3,15 +3,12 @@
 // license that can be found in the LICENSE file.
 
 // Package xml implements a simple XML 1.0 parser that
-// understands XML name spaces.
+// understands XML namespaces.
 package xml
 
 // References:
 //    Annotated XML spec: https://www.xml.com/axml/testaxml.htm
-//    XML name spaces: https://www.w3.org/TR/REC-xml-names/
-
-// TODO(rsc):
-//	Test error handling.
+//    XML namespaces: https://www.w3.org/TR/REC-xml-names/
 
 import (
 	"bufio"
@@ -36,10 +33,13 @@ func (e *SyntaxError) Error() string {
 }
 
 // A Name represents an XML name (Local) annotated
-// with a name space identifier (Space).
-// In tokens returned by Decoder.Token, the Space identifier
+// with a namespace identifier (Space).
+// In tokens returned by [Decoder.Token], the Space identifier
 // is given as a canonical URL, not the short prefix used
-// in the document being parsed.
+// in the document being parsed. If Local is prefixed in
+// the form of "prefix:name", this package will attempt to
+// use the prefix instead of a fully-qualified namespace URL
+// when marshaling.
 type Name struct {
 	Space, Local string
 }
@@ -51,8 +51,8 @@ type Attr struct {
 }
 
 // A Token is an interface holding one of the token types:
-// StartElement, EndElement, CharData, Comment, ProcInst, or Directive.
-type Token interface{}
+// [StartElement], [EndElement], [CharData], [Comment], [ProcInst], or [Directive].
+type Token any
 
 // A StartElement represents an XML start element.
 type StartElement struct {
@@ -83,21 +83,15 @@ type EndElement struct {
 // the characters they represent.
 type CharData []byte
 
-func makeCopy(b []byte) []byte {
-	b1 := make([]byte, len(b))
-	copy(b1, b)
-	return b1
-}
-
 // Copy creates a new copy of CharData.
-func (c CharData) Copy() CharData { return CharData(makeCopy(c)) }
+func (c CharData) Copy() CharData { return CharData(bytes.Clone(c)) }
 
 // A Comment represents an XML comment of the form <!--comment-->.
 // The bytes do not include the <!-- and --> comment markers.
 type Comment []byte
 
 // Copy creates a new copy of Comment.
-func (c Comment) Copy() Comment { return Comment(makeCopy(c)) }
+func (c Comment) Copy() Comment { return Comment(bytes.Clone(c)) }
 
 // A ProcInst represents an XML processing instruction of the form <?target inst?>
 type ProcInst struct {
@@ -107,7 +101,7 @@ type ProcInst struct {
 
 // Copy creates a new copy of ProcInst.
 func (p ProcInst) Copy() ProcInst {
-	p.Inst = makeCopy(p.Inst)
+	p.Inst = bytes.Clone(p.Inst)
 	return p
 }
 
@@ -116,7 +110,7 @@ func (p ProcInst) Copy() ProcInst {
 type Directive []byte
 
 // Copy creates a new copy of Directive.
-func (d Directive) Copy() Directive { return Directive(makeCopy(d)) }
+func (d Directive) Copy() Directive { return Directive(bytes.Clone(d)) }
 
 // CopyToken returns a copy of a Token.
 func CopyToken(t Token) Token {
@@ -136,14 +130,14 @@ func CopyToken(t Token) Token {
 }
 
 // A TokenReader is anything that can decode a stream of XML tokens, including a
-// Decoder.
+// [Decoder].
 //
 // When Token encounters an error or end-of-file condition after successfully
 // reading a token, it returns the token. It may return the (non-nil) error from
 // the same call or return the error (and a nil token) from a subsequent call.
 // An instance of this general case is that a TokenReader returning a non-nil
 // token at the end of the token stream may return either io.EOF or a nil error.
-// The next Read should return nil, io.EOF.
+// The next Read should return nil, [io.EOF].
 //
 // Implementations of Token are discouraged from returning a nil token with a
 // nil error. Callers should treat a return of nil, nil as indicating that
@@ -173,9 +167,9 @@ type Decoder struct {
 	//
 	// creates a parser that can handle typical HTML.
 	//
-	// Strict mode does not enforce the requirements of the XML name spaces TR.
-	// In particular it does not reject name space tags using undefined prefixes.
-	// Such tags are recorded with the unknown prefix as the name space URL.
+	// Strict mode does not enforce the requirements of the XML namespaces TR.
+	// In particular it does not reject namespace tags using undefined prefixes.
+	// Such tags are recorded with the unknown prefix as the namespace URL.
 	Strict bool
 
 	// When Strict == false, AutoClose indicates a set of elements to
@@ -201,7 +195,7 @@ type Decoder struct {
 	// CharsetReader's result values must be non-nil.
 	CharsetReader func(charset string, input io.Reader) (io.Reader, error)
 
-	// DefaultSpace sets the default name space used for unadorned tags,
+	// DefaultSpace sets the default namespace used for unadorned tags,
 	// as if the entire XML stream were wrapped in an element containing
 	// the attribute xmlns="DefaultSpace".
 	DefaultSpace string
@@ -219,12 +213,13 @@ type Decoder struct {
 	ns             map[string]string // url for a prefix ns[.Space]=.Value
 	err            error
 	line           int
+	linestart      int64
 	offset         int64
 	unmarshalDepth int
 }
 
 // NewDecoder creates a new XML parser reading from r.
-// If r does not implement io.ByteReader, NewDecoder will
+// If r does not implement [io.ByteReader], NewDecoder will
 // do its own buffering.
 func NewDecoder(r io.Reader) *Decoder {
 	d := &Decoder{
@@ -254,27 +249,30 @@ func NewTokenDecoder(t TokenReader) *Decoder {
 }
 
 // Token returns the next XML token in the input stream.
-// At the end of the input stream, Token returns nil, io.EOF.
+// At the end of the input stream, Token returns nil, [io.EOF].
 //
 // Slices of bytes in the returned token data refer to the
 // parser's internal buffer and remain valid only until the next
-// call to Token. To acquire a copy of the bytes, call CopyToken
+// call to Token. To acquire a copy of the bytes, call [CopyToken]
 // or the token's Copy method.
 //
 // Token expands self-closing elements such as <br>
 // into separate start and end elements returned by successive calls.
 //
-// Token guarantees that the StartElement and EndElement
+// Token guarantees that the [StartElement] and [EndElement]
 // tokens it returns are properly nested and matched:
 // if Token encounters an unexpected end element
 // or EOF before all expected end elements,
 // it will return an error.
 //
-// Token implements XML name spaces as described by
+// If [Decoder.CharsetReader] is called and returns an error,
+// the error is wrapped and returned.
+//
+// Token implements XML namespaces as described by
 // https://www.w3.org/TR/REC-xml-names/. Each of the
-// Name structures contained in the Token has the Space
-// set to the URL identifying its name space when known.
-// If Token encounters an unrecognized name space prefix,
+// [Name] structures contained in the Token has the Space
+// set to the URL identifying its namespace when known.
+// If Token encounters an unrecognized namespace prefix,
 // it uses the prefix as the Space rather than report an error.
 func (d *Decoder) Token() (Token, error) {
 	var t Token
@@ -304,12 +302,12 @@ func (d *Decoder) Token() (Token, error) {
 	}
 	switch t1 := t.(type) {
 	case StartElement:
-		// In XML name spaces, the translations listed in the
+		// In XML namespaces, the translations listed in the
 		// attributes apply to the element name and
 		// to the other attribute names, so process
 		// the translations first.
 		for _, a := range t1.Attr {
-			if a.Name.Space == xmlnsPrefix { // name space attribute {.Space}xmlns:{.Local}={.Value}
+			if a.Name.Space == xmlnsPrefix { // namespace attribute {.Space}xmlns:{.Local}={.Value}
 				if a.Value == "" {
 					d.err = d.syntaxError("empty namespace without prefix")
 					return nil, d.err
@@ -319,20 +317,19 @@ func (d *Decoder) Token() (Token, error) {
 					return nil, d.err
 				}
 				v, ok := d.ns[a.Name.Local] // Checking existence
-				// Recording the level of the name space by recording tag name
+				// Recording the level of the namespace by recording tag name
 				d.pushNs(a.Name.Local, v, ok) // Pushing tag, eventual value, and existence of namespace
 				d.ns[a.Name.Local] = a.Value
 			}
 			if a.Name.Space == "" && a.Name.Local == xmlnsPrefix { // xmlns=".Value"
-				// Default space for non-prefixed names
+				// Default namespace for non-prefixed names
 				v, ok := d.ns[""]
 				d.pushNs("", v, ok)
 				d.ns[""] = a.Value
 			}
 		}
 
-		d.pushElement(t1.Name) // Pushing the element with its eventual prefix
-		// Assigning value to Space of the attributed using the NS bindings
+		d.pushElement(t1.Name)
 		d.translate(&t1.Name, true)
 		for i := range t1.Attr {
 			d.translate(&t1.Attr[i].Name, false)
@@ -340,7 +337,7 @@ func (d *Decoder) Token() (Token, error) {
 		t = t1
 
 	case EndElement:
-		if !d.popElement(&t1) { // Popping the element with its eventual prefix for appropriate comparison
+		if !d.popElement(&t1) {
 			return nil, d.err
 		}
 		t = t1
@@ -355,8 +352,8 @@ const (
 	xmlnsPrefix = "xmlns"
 )
 
-// Apply name space translation to name n.
-// The default name space (for Space=="")
+// Apply namespace translation to name n.
+// The default namespace (for Space=="")
 // applies only to element names, not to attribute names.
 func (d *Decoder) translate(n *Name, isElementName bool) {
 	switch {
@@ -389,7 +386,7 @@ func (d *Decoder) switchToReader(r io.Reader) {
 	}
 }
 
-// Parsing state - stack holds old name space translations
+// Parsing state - stack holds old namespace translations
 // and the current set of open elements. The translations to pop when
 // ending a given tag are *below* it on the stack, which is
 // more work but forced on us by XML.
@@ -509,13 +506,16 @@ func (d *Decoder) popElement(t *EndElement) bool {
 		d.err = d.syntaxError("element <" + s.name.Local + "> closed by </" + name.Local + ">")
 		return false
 	case s.name.Space != name.Space:
-		d.err = d.syntaxError("element <" + s.name.Local + "> in space " + s.name.Space +
-			" closed by </" + name.Local + "> in space " + name.Space)
+		ns := name.Space
+		if name.Space == "" {
+			ns = `""`
+		}
+		d.err = d.syntaxError("element <" + s.name.Local + "> in namespace " + s.name.Space +
+			" closed by </" + name.Local + "> in namespace " + ns)
 		return false
 	}
 
-	// translating before removal of ns
-	d.translate(&t.Name, true) // returning a namespace and not its prefix as doc says
+	d.translate(&t.Name, true)
 
 	// Pop stack until a Start or EOF is on the top, undoing the
 	// translations that were associated with the element we just closed.
@@ -537,12 +537,11 @@ func (d *Decoder) autoClose(t Token) (Token, bool) {
 	if d.stk == nil || d.stk.kind != stkStart {
 		return nil, false
 	}
-	name := strings.ToLower(d.stk.name.Local)
 	for _, s := range d.AutoClose {
-		if strings.ToLower(s) == name {
+		if strings.EqualFold(s, d.stk.name.Local) {
 			// This one should be auto closed if t doesn't close it.
 			et, ok := t.(EndElement)
-			if !ok || et.Name.Local != name {
+			if !ok || !strings.EqualFold(et.Name.Local, d.stk.name.Local) {
 				return EndElement{d.stk.name}, true
 			}
 			break
@@ -553,9 +552,9 @@ func (d *Decoder) autoClose(t Token) (Token, bool) {
 
 var errRawToken = errors.New("xml: cannot use RawToken from UnmarshalXML method")
 
-// RawToken is like Token but does not verify that
+// RawToken is like [Decoder.Token] but does not verify that
 // start and end elements match and does not translate
-// name space prefixes to their corresponding URLs.
+// namespace prefixes to their corresponding URLs.
 func (d *Decoder) RawToken() (Token, error) {
 	if d.unmarshalDepth > 0 {
 		return nil, errRawToken
@@ -656,7 +655,7 @@ func (d *Decoder) rawToken() (Token, error) {
 				}
 				newr, err := d.CharsetReader(enc, d.r.(io.Reader))
 				if err != nil {
-					d.err = fmt.Errorf("xml: opening charset %q: %v", enc, err)
+					d.err = fmt.Errorf("xml: opening charset %q: %w", enc, err)
 					return nil, d.err
 				}
 				if newr == nil {
@@ -939,6 +938,7 @@ func (d *Decoder) getc() (b byte, ok bool) {
 	}
 	if b == '\n' {
 		d.line++
+		d.linestart = d.offset + 1
 	}
 	d.offset++
 	return b, true
@@ -949,6 +949,13 @@ func (d *Decoder) getc() (b byte, ok bool) {
 // and the beginning of the next token.
 func (d *Decoder) InputOffset() int64 {
 	return d.offset
+}
+
+// InputPos returns the line of the current decoder position and the 1 based
+// input position of the line. The position gives the location of the end of the
+// most recently returned token.
+func (d *Decoder) InputPos() (line, column int) {
+	return d.line, int(d.offset-d.linestart) + 1
 }
 
 // Return saved offset.
@@ -1013,8 +1020,9 @@ Input:
 		}
 
 		// <![CDATA[ section ends with ]]>.
-		// It is an error for ]]> to appear in ordinary text.
-		if b0 == ']' && b1 == ']' && b == '>' {
+		// It is an error for ]]> to appear in ordinary text,
+		// but it is allowed in quoted strings.
+		if quote < 0 && b0 == ']' && b1 == ']' && b == '>' {
 			if cdata {
 				trunc = 2
 				break Input
@@ -1116,7 +1124,7 @@ Input:
 
 			if haveText {
 				d.buf.Truncate(before)
-				d.buf.Write([]byte(text))
+				d.buf.WriteString(text)
 				b0, b1 = 0, 0
 				continue Input
 			}
@@ -1177,8 +1185,8 @@ func isInCharacterRange(r rune) (inrange bool) {
 		r >= 0x10000 && r <= 0x10FFFF
 }
 
-// Get name space name: name with a : stuck in the middle.
-// The part before the : is the name space identifier.
+// Get namespace name: name with a : stuck in the middle.
+// The part before the : is the namespace identifier.
 func (d *Decoder) nsname() (name Name, ok bool) {
 	s, ok := d.name()
 	if !ok {
@@ -1620,7 +1628,7 @@ var second = &unicode.RangeTable{
 // HTMLEntity is an entity map containing translations for the
 // standard HTML entity characters.
 //
-// See the Decoder.Strict and Decoder.Entity fields' documentation.
+// See the [Decoder.Strict] and [Decoder.Entity] fields' documentation.
 var HTMLEntity map[string]string = htmlEntity
 
 var htmlEntity = map[string]string{
@@ -1889,7 +1897,7 @@ var htmlEntity = map[string]string{
 // HTMLAutoClose is the set of HTML elements that
 // should be considered to close automatically.
 //
-// See the Decoder.Strict and Decoder.Entity fields' documentation.
+// See the [Decoder.Strict] and [Decoder.Entity] fields' documentation.
 var HTMLAutoClose []string = htmlAutoClose
 
 var htmlAutoClose = []string{
@@ -2015,9 +2023,9 @@ func (p *printer) EscapeString(s string) {
 	p.WriteString(s[last:])
 }
 
-// Escape is like EscapeText but omits the error return value.
+// Escape is like [EscapeText] but omits the error return value.
 // It is provided for backwards compatibility with Go 1.0.
-// Code targeting Go 1.1 or later should use EscapeText.
+// Code targeting Go 1.1 or later should use [EscapeText].
 func Escape(w io.Writer, s []byte) {
 	EscapeText(w, s)
 }
@@ -2037,25 +2045,26 @@ func emitCDATA(w io.Writer, s []byte) error {
 	if _, err := w.Write(cdataStart); err != nil {
 		return err
 	}
+
 	for {
-		i := bytes.Index(s, cdataEnd)
-		if i >= 0 && i+len(cdataEnd) <= len(s) {
-			// Found a nested CDATA directive end.
-			if _, err := w.Write(s[:i]); err != nil {
-				return err
-			}
-			if _, err := w.Write(cdataEscape); err != nil {
-				return err
-			}
-			i += len(cdataEnd)
-		} else {
-			if _, err := w.Write(s); err != nil {
-				return err
-			}
+		before, after, ok := bytes.Cut(s, cdataEnd)
+		if !ok {
 			break
 		}
-		s = s[i:]
+		// Found a nested CDATA directive end.
+		if _, err := w.Write(before); err != nil {
+			return err
+		}
+		if _, err := w.Write(cdataEscape); err != nil {
+			return err
+		}
+		s = after
 	}
+
+	if _, err := w.Write(s); err != nil {
+		return err
+	}
+
 	_, err := w.Write(cdataEnd)
 	return err
 }
@@ -2066,20 +2075,27 @@ func procInst(param, s string) string {
 	// TODO: this parsing is somewhat lame and not exact.
 	// It works for all actual cases, though.
 	param = param + "="
-	idx := strings.Index(s, param)
-	if idx == -1 {
+	lenp := len(param)
+	i := 0
+	var sep byte
+	for i < len(s) {
+		sub := s[i:]
+		k := strings.Index(sub, param)
+		if k < 0 || lenp+k >= len(sub) {
+			return ""
+		}
+		i += lenp + k + 1
+		if c := sub[lenp+k]; c == '\'' || c == '"' {
+			sep = c
+			break
+		}
+	}
+	if sep == 0 {
 		return ""
 	}
-	v := s[idx+len(param):]
-	if v == "" {
+	j := strings.IndexByte(s[i:], sep)
+	if j < 0 {
 		return ""
 	}
-	if v[0] != '\'' && v[0] != '"' {
-		return ""
-	}
-	idx = strings.IndexRune(v[1:], rune(v[0]))
-	if idx == -1 {
-		return ""
-	}
-	return v[1 : idx+1]
+	return s[i : i+j]
 }

--- a/xml/xml_test.go
+++ b/xml/xml_test.go
@@ -502,6 +502,45 @@ func TestSyntax(t *testing.T) {
 	}
 }
 
+func TestInputLinePos(t *testing.T) {
+	testInput := `<root>
+<?pi
+ ?>  <elt
+att
+=
+"val">
+<![CDATA[
+]]><!--
+
+--></elt>
+</root>`
+	linePos := [][]int{
+		{1, 7},
+		{2, 1},
+		{3, 4},
+		{3, 6},
+		{6, 7},
+		{7, 1},
+		{8, 4},
+		{10, 4},
+		{10, 10},
+		{11, 1},
+		{11, 8},
+	}
+	dec := NewDecoder(strings.NewReader(testInput))
+	for _, want := range linePos {
+		if _, err := dec.Token(); err != nil {
+			t.Errorf("Unexpected error: %v", err)
+			continue
+		}
+
+		gotLine, gotCol := dec.InputPos()
+		if gotLine != want[0] || gotCol != want[1] {
+			t.Errorf("dec.InputPos() = %d,%d, want %d,%d", gotLine, gotCol, want[0], want[1])
+		}
+	}
+}
+
 type allScalars struct {
 	True1     bool
 	True2     bool
@@ -587,6 +626,30 @@ type item struct {
 	FieldA string
 }
 
+func TestIssue68387(t *testing.T) {
+	data := `<item b=']]>'/>`
+	dec := NewDecoder(strings.NewReader(data))
+	var tok1, tok2, tok3 Token
+	var err error
+	if tok1, err = dec.RawToken(); err != nil {
+		t.Fatalf("RawToken() failed: %v", err)
+	}
+	if tok2, err = dec.RawToken(); err != nil {
+		t.Fatalf("RawToken() failed: %v", err)
+	}
+	if tok3, err = dec.RawToken(); err != io.EOF || tok3 != nil {
+		t.Fatalf("Missed EOF")
+	}
+	s := StartElement{Name{"", "item"}, []Attr{Attr{Name{"","b"}, "]]>"}}}
+	if !reflect.DeepEqual(tok1.(StartElement), s) {
+		t.Error("Wrong start element")
+	}
+	e := EndElement{Name{"","item"}}
+	if tok2.(EndElement) != e {
+		t.Error("Wrong end element")
+	}
+}
+
 func TestIssue569(t *testing.T) {
 	data := `<item><FieldA>abcd</FieldA></item>`
 	var i item
@@ -670,6 +733,19 @@ func TestCopyTokenStartElement(t *testing.T) {
 	tok1.(StartElement).Attr[0] = Attr{Name{"", "lang"}, "de"}
 	if reflect.DeepEqual(tok1, tok2) {
 		t.Error("CopyToken(CharData) uses same buffer.")
+	}
+}
+
+func TestCopyTokenComment(t *testing.T) {
+	data := []byte("<!-- some comment -->")
+	var tok1 Token = Comment(data)
+	tok2 := CopyToken(tok1)
+	if !reflect.DeepEqual(tok1, tok2) {
+		t.Error("CopyToken(Comment) != Comment")
+	}
+	data[1] = 'o'
+	if reflect.DeepEqual(tok1, tok2) {
+		t.Error("CopyToken(Comment) uses same buffer.")
 	}
 }
 
@@ -778,6 +854,13 @@ var procInstTests = []struct {
 	{`version="1.0" encoding='utf-8' `, [2]string{"1.0", "utf-8"}},
 	{`version="1.0" encoding=utf-8`, [2]string{"1.0", ""}},
 	{`encoding="FOO" `, [2]string{"", "FOO"}},
+	{`version=2.0 version="1.0" encoding=utf-7 encoding='utf-8'`, [2]string{"1.0", "utf-8"}},
+	{`version= encoding=`, [2]string{"", ""}},
+	{`encoding="version=1.0"`, [2]string{"", "version=1.0"}},
+	{``, [2]string{"", ""}},
+	// TODO: what's the right approach to handle these nested cases?
+	{`encoding="version='1.0'"`, [2]string{"1.0", "version='1.0'"}},
+	{`version="encoding='utf-8'"`, [2]string{"encoding='utf-8'", "utf-8"}},
 }
 
 func TestProcInstEncoding(t *testing.T) {
@@ -842,7 +925,7 @@ func TestEscapeTextInvalidChar(t *testing.T) {
 	input := []byte("A \x00 terminated string.")
 	expected := "A \uFFFD terminated string."
 
-	buff := new(bytes.Buffer)
+	buff := new(strings.Builder)
 	if err := EscapeText(buff, input); err != nil {
 		t.Fatalf("have %v, want nil", err)
 	}
@@ -869,26 +952,92 @@ func TestIssue8535(t *testing.T) {
 	type ExampleConflict struct {
 		XMLName  Name   `xml:"example"`
 		Link     string `xml:"link"`
-		AtomLink string `xml:"http://www.w3.org/2005/Atom link"` // No conflict but no assignment
+		AtomLink string `xml:"http://www.w3.org/2005/Atom link"` // Same name in a different namespace
 	}
-	testCases := []string{
-		`<example>
-    		<title>Example</title>
+	testCase := `<example>
+			<title>Example</title>
 			<link>http://example.com/default</link> <!-- not assigned -->
 			<link>http://example.com/home</link> <!-- not assigned -->
 			<ns:link xmlns:ns="http://www.w3.org/2005/Atom">http://example.com/ns</ns:link>
-		</example>`,
-	}
+		</example>`
 
 	var dest ExampleConflict
-	d := NewDecoder(strings.NewReader(testCases[0]))
+	d := NewDecoder(strings.NewReader(testCase))
 	if err := d.Decode(&dest); err != nil {
-		t.Errorf("%s: Field conflicts : got error %v, want no fail", testCases[0], err)
+		t.Fatal(err)
 	}
 }
 
-func TestIssue11431(t *testing.T) { //
+func TestEncodeXMLNS(t *testing.T) {
+	testCases := []struct {
+		f    func() ([]byte, error)
+		want string
+		ok   bool
+	}{
+		{encodeXMLNS1, `<Test xmlns="http://example.com/ns"><Body>hello world</Body></Test>`, true},
+		{encodeXMLNS2, `<Test><body xmlns="http://example.com/ns">hello world</body></Test>`, true},
+		{encodeXMLNS3, `<Test xmlns="http://example.com/ns"><Body>hello world</Body></Test>`, true},
+		{encodeXMLNS4, `<Test xmlns="http://example.com/ns"><Body>hello world</Body></Test>`, false},
+	}
 
+	for i, tc := range testCases {
+		if b, err := tc.f(); err == nil {
+			if got, want := string(b), tc.want; got != want {
+				t.Errorf("%d: got %s, want %s \n", i, got, want)
+			}
+		} else {
+			t.Errorf("%d: marshal failed with %s", i, err)
+		}
+	}
+}
+
+func encodeXMLNS1() ([]byte, error) {
+
+	type T struct {
+		XMLName Name   `xml:"Test"`
+		Ns      string `xml:"xmlns,attr"`
+		Body    string
+	}
+
+	s := &T{Ns: "http://example.com/ns", Body: "hello world"}
+	return Marshal(s)
+}
+
+func encodeXMLNS2() ([]byte, error) {
+
+	type Test struct {
+		Body string `xml:"http://example.com/ns body"`
+	}
+
+	s := &Test{Body: "hello world"}
+	return Marshal(s)
+}
+
+func encodeXMLNS3() ([]byte, error) {
+
+	type Test struct {
+		XMLName Name `xml:"http://example.com/ns Test"`
+		Body    string
+	}
+
+	//s := &Test{XMLName: Name{"http://example.com/ns",""}, Body: "hello world"} is unusable as the "-" is missing
+	// as documentation states
+	s := &Test{Body: "hello world"}
+	return Marshal(s)
+}
+
+func encodeXMLNS4() ([]byte, error) {
+
+	type Test struct {
+		Ns   string `xml:"xmlns,attr"`
+		Body string
+	}
+
+	s := &Test{Ns: "http://example.com/ns", Body: "hello world"}
+	return Marshal(s)
+}
+
+func TestIssue11431(t *testing.T) {
 	type Test struct {
 		XMLName Name   `xml:"Test"`
 		Ns      string `xml:"xmlns,attr"`
@@ -908,7 +1057,6 @@ func TestIssue11431(t *testing.T) { //
 }
 
 func TestIssue11431NsWoAttr(t *testing.T) {
-
 	type Test struct {
 		Body string `xml:"http://example.com/ns body"`
 	}
@@ -925,8 +1073,7 @@ func TestIssue11431NsWoAttr(t *testing.T) {
 	}
 }
 
-func TestIssue11431XMLName(t *testing.T) { //
-
+func TestIssue11431XMLName(t *testing.T) {
 	type Test struct {
 		XMLName Name `xml:"http://example.com/ns Test"`
 		Body    string
@@ -946,8 +1093,7 @@ func TestIssue11431XMLName(t *testing.T) { //
 	}
 }
 
-func TestIssue11431UsingAttr(t *testing.T) { //
-
+func TestIssue11431UsingAttr(t *testing.T) {
 	type T struct {
 		Ns   string `xml:"xmlns,attr"`
 		Body string
@@ -968,7 +1114,6 @@ func TestIssue11431UsingAttr(t *testing.T) { //
 }
 
 func TestIssue11496(t *testing.T) { // Issue answered
-
 	type Person struct {
 		XMLName Name   `xml:"ns1 person"`
 		Name    string `xml:"name"`
@@ -1005,7 +1150,6 @@ func TestIssue11496(t *testing.T) { // Issue answered
 }
 
 func TestIssue8068(t *testing.T) {
-
 	testCases := []struct {
 		s  string
 		ok bool
@@ -1256,35 +1400,91 @@ func TestIssue12417(t *testing.T) {
 	}
 }
 
-func TestIssue20396(t *testing.T) {
-	testCases := []struct {
-		s  string
-		ok bool
-	}{ // Should not allow to change namespace of opening tag
-		{`<a:te:st xmlns:a="abcd"/>`, false},
-		{`<a:te=st xmlns:a="abcd"/>`, false},
-		{`<a:te&st xmlns:a="abcd"/>`, false},
-		{`<a:test xmlns:a="abcd"/>`, true},
+func TestIssue7113(t *testing.T) {
+	type C struct {
+		XMLName Name `xml:""` // Sets empty namespace
 	}
+
+	type D struct {
+		XMLName Name `xml:"d"`
+	}
+
+	type A struct {
+		XMLName Name `xml:""`
+		C       C    `xml:""`
+		D       D
+	}
+
+	var a A
+	structSpace := "b"
+	xmlTest := `<A xmlns="` + structSpace + `"><C xmlns=""></C><d></d></A>`
+	t.Log(xmlTest)
+	err := Unmarshal([]byte(xmlTest), &a)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if a.XMLName.Space != structSpace {
+		t.Errorf("overidding with empty namespace: unmarshaling, got %s, want %s\n", a.XMLName.Space, structSpace)
+	}
+	if len(a.C.XMLName.Space) != 0 {
+		t.Fatalf("overidding with empty namespace: unmarshaling, got %s, want empty\n", a.C.XMLName.Space)
+	}
+
+	var b []byte
+	b, err = Marshal(&a)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(a.C.XMLName.Space) != 0 {
+		t.Errorf("overidding with empty namespace: marshaling, got %s in C tag which should be empty\n", a.C.XMLName.Space)
+	}
+	if string(b) != xmlTest {
+		t.Fatalf("overidding with empty namespace: marshaling, got %s, want %s\n", b, xmlTest)
+	}
+	var c A
+	err = Unmarshal(b, &c)
+	if err != nil {
+		t.Fatalf("second Unmarshal failed: %s", err)
+	}
+	if c.XMLName.Space != "b" {
+		t.Errorf("overidding with empty namespace: after marshaling & unmarshaling, XML namespace: got %s, want %s\n", a.XMLName.Space, structSpace)
+	}
+	if len(c.C.XMLName.Space) != 0 {
+		t.Errorf("overidding with empty namespace: after marshaling & unmarshaling, got %s, want empty\n", a.C.XMLName.Space)
+	}
+}
+
+func TestIssue20396(t *testing.T) {
+
+	var attrError = UnmarshalError("XML syntax error on line 1: expected attribute name in element")
+
+	testCases := []struct {
+		s       string
+		wantErr error
+	}{
+		{`<a:te:st xmlns:a="abcd"/>`, // Issue 20396
+			UnmarshalError("XML syntax error on line 1: expected element name after <")},
+		{`<a:te=st xmlns:a="abcd"/>`, attrError},
+		{`<a:te&st xmlns:a="abcd"/>`, attrError},
+		{`<a:test xmlns:a="abcd"/>`, nil},
+		{`<a:te:st xmlns:a="abcd">1</a:te:st>`,
+			UnmarshalError("XML syntax error on line 1: expected element name after <")},
+		{`<a:te=st xmlns:a="abcd">1</a:te=st>`, attrError},
+		{`<a:te&st xmlns:a="abcd">1</a:te&st>`, attrError},
+		{`<a:test xmlns:a="abcd">1</a:test>`, nil},
+	}
+
+	var dest string
 	for _, tc := range testCases {
-		d := NewDecoder(strings.NewReader(tc.s))
-		var err error
-		for {
-			_, err = d.Token()
-			if err != nil {
-				if err == io.EOF { //EOF indicates that process is complete
-					err = nil
-				}
-				break
+		if got, want := Unmarshal([]byte(tc.s), &dest), tc.wantErr; got != want {
+			if got == nil {
+				t.Errorf("%s: Unexpected success, want %v", tc.s, want)
+			} else if want == nil {
+				t.Errorf("%s: Unexpected error, got %v", tc.s, got)
+			} else if got.Error() != want.Error() {
+				t.Errorf("%s: got %v, want %v", tc.s, got, want)
 			}
-		}
-		if err != nil && tc.ok {
-			err = d.err
-			t.Errorf("%q: Multiple colons in tag : expected no error, got %s", tc.s, err)
-			continue
-		}
-		if err == nil && !tc.ok {
-			t.Errorf("%q: Multiple colons in tag : expected error, got nil", tc.s)
 		}
 	}
 }
@@ -1564,63 +1764,6 @@ func TestMarshalXMLName(t *testing.T) {
 	}
 }
 
-func TestIssue7113(t *testing.T) {
-	type C struct {
-		XMLName Name `xml:""` // To reset namespace to ""
-	}
-
-	type A struct {
-		XMLName Name `xml:""`
-		C       C    `xml:""`
-	}
-
-	var a A
-	structSpace := "b"
-	fieldSpace := ""
-	xmlTests := []string{
-		`<A xmlns="` + structSpace + `"><C xmlns="` + fieldSpace + `"></C></A>`,
-		// `<A><C></C></A>`,
-	}
-	for _, xmltest := range xmlTests {
-
-		err := Unmarshal([]byte(xmltest), &a)
-		if err != nil {
-			t.Errorf("overidding with empty namespace: expected no error, got %s", err)
-		}
-		if a.XMLName.Space != structSpace {
-			t.Errorf("overidding with empty namespace: before marshaling, got %s != %s, want == \n", a.XMLName.Space, structSpace)
-		}
-		if a.C.XMLName.Space != fieldSpace {
-			t.Errorf("overidding with empty namespace: before marshaling, got %s != %s, want == \n", a.C.XMLName.Space, fieldSpace)
-		}
-
-		var b []byte
-		/* Because of unmarshaling, namespaces are already assigned */
-		b, err = Marshal(&a)
-		if string(b) != xmltest {
-			t.Errorf("overidding with empty namespace: after marshaling, got %s != %s, want == \n", string(b), xmltest)
-			return
-		}
-		// Unmarshaling has no interest if the previous test succeed as the structs are initially empty unless
-		if a.C.XMLName.Local != "C" {
-			t.Errorf("overidding with empty namespace: after marshaling, unmarshaling will fail, got %s as C tag space which should be tag name C \n", a.C.XMLName.Local)
-		}
-		if a.C.XMLName.Space != "" {
-			t.Errorf("overidding with empty namespace: after marshaling, unmarshaling will fail, got %s in C tag which should be empty \n", a.C.XMLName.Space)
-		}
-		err = Unmarshal(b, &a)
-		if err != nil {
-			t.Errorf("overidding with empty namespace: expected no error, got %s", err)
-		}
-		if a.XMLName.Space != "b" {
-			t.Errorf("overidding with empty namespace: after marshaling & unmarshaling, got %s in XMLName != %s, want == \n", a.XMLName.Space, "b")
-		}
-		if a.C.XMLName.Space != "" {
-			t.Errorf("overidding with empty namespace: after marshaling & unmarshaling, got %q in C tag != %q, want == \n", a.C.XMLName.Space, "")
-		}
-	}
-}
-
 func tokenMap(mapping func(t Token) Token) func(TokenReader) TokenReader {
 	return func(src TokenReader) TokenReader {
 		return mapper{
@@ -1764,5 +1907,160 @@ func TestRoundTrip(t *testing.T) {
 	}
 	for name, input := range tests {
 		t.Run(name, func(t *testing.T) { testRoundTrip(t, input) })
+	}
+}
+
+func TestParseErrors(t *testing.T) {
+	withDefaultHeader := func(s string) string {
+		return `<?xml version="1.0" encoding="UTF-8"?>` + s
+	}
+	tests := []struct {
+		src string
+		err string
+	}{
+		{withDefaultHeader(`</foo>`), `unexpected end element </foo>`},
+		{withDefaultHeader(`<x:foo></y:foo>`), `element <foo> in namespace x closed by </foo> in namespace y`},
+		{withDefaultHeader(`<? not ok ?>`), `expected target name after <?`},
+		{withDefaultHeader(`<!- not ok -->`), `invalid sequence <!- not part of <!--`},
+		{withDefaultHeader(`<!-? not ok -->`), `invalid sequence <!- not part of <!--`},
+		{withDefaultHeader(`<![not ok]>`), `invalid <![ sequence`},
+		{withDefaultHeader(`<zzz:foo xmlns:zzz="http://example.com"><bar>baz</bar></foo>`),
+			`element <foo> in namespace zzz closed by </foo> in namespace ""`},
+		{withDefaultHeader("\xf1"), `invalid UTF-8`},
+
+		// Header-related errors.
+		{`<?xml version="1.1" encoding="UTF-8"?>`, `unsupported version "1.1"; only version 1.0 is supported`},
+
+		// Cases below are for "no errors".
+		{withDefaultHeader(`<?ok?>`), ``},
+		{withDefaultHeader(`<?ok version="ok"?>`), ``},
+	}
+
+	for _, test := range tests {
+		d := NewDecoder(strings.NewReader(test.src))
+		var err error
+		for {
+			_, err = d.Token()
+			if err != nil {
+				break
+			}
+		}
+		if test.err == "" {
+			if err != io.EOF {
+				t.Errorf("parse %s: have %q error, expected none", test.src, err)
+			}
+			continue
+		}
+		// Inv: err != nil
+		if err == io.EOF {
+			t.Errorf("parse %s: unexpected EOF", test.src)
+			continue
+		}
+		if !strings.Contains(err.Error(), test.err) {
+			t.Errorf("parse %s: can't find %q error substring\nerror: %q", test.src, test.err, err)
+			continue
+		}
+	}
+}
+
+const testInputHTMLAutoClose = `<?xml version="1.0" encoding="UTF-8"?>
+<br>
+<br/><br/>
+<br><br>
+<br></br>
+<BR>
+<BR/><BR/>
+<Br></Br>
+<BR><span id="test">abc</span><br/><br/>`
+
+func BenchmarkHTMLAutoClose(b *testing.B) {
+	b.RunParallel(func(p *testing.PB) {
+		for p.Next() {
+			d := NewDecoder(strings.NewReader(testInputHTMLAutoClose))
+			d.Strict = false
+			d.AutoClose = HTMLAutoClose
+			d.Entity = HTMLEntity
+			for {
+				_, err := d.Token()
+				if err != nil {
+					if err == io.EOF {
+						break
+					}
+					b.Fatalf("unexpected error: %v", err)
+				}
+			}
+		}
+	})
+}
+
+func TestHTMLAutoClose(t *testing.T) {
+	wantTokens := []Token{
+		ProcInst{"xml", []byte(`version="1.0" encoding="UTF-8"`)},
+		CharData("\n"),
+		StartElement{Name{"", "br"}, []Attr{}},
+		EndElement{Name{"", "br"}},
+		CharData("\n"),
+		StartElement{Name{"", "br"}, []Attr{}},
+		EndElement{Name{"", "br"}},
+		StartElement{Name{"", "br"}, []Attr{}},
+		EndElement{Name{"", "br"}},
+		CharData("\n"),
+		StartElement{Name{"", "br"}, []Attr{}},
+		EndElement{Name{"", "br"}},
+		StartElement{Name{"", "br"}, []Attr{}},
+		EndElement{Name{"", "br"}},
+		CharData("\n"),
+		StartElement{Name{"", "br"}, []Attr{}},
+		EndElement{Name{"", "br"}},
+		CharData("\n"),
+		StartElement{Name{"", "BR"}, []Attr{}},
+		EndElement{Name{"", "BR"}},
+		CharData("\n"),
+		StartElement{Name{"", "BR"}, []Attr{}},
+		EndElement{Name{"", "BR"}},
+		StartElement{Name{"", "BR"}, []Attr{}},
+		EndElement{Name{"", "BR"}},
+		CharData("\n"),
+		StartElement{Name{"", "Br"}, []Attr{}},
+		EndElement{Name{"", "Br"}},
+		CharData("\n"),
+		StartElement{Name{"", "BR"}, []Attr{}},
+		EndElement{Name{"", "BR"}},
+		StartElement{Name{"", "span"}, []Attr{{Name: Name{"", "id"}, Value: "test"}}},
+		CharData("abc"),
+		EndElement{Name{"", "span"}},
+		StartElement{Name{"", "br"}, []Attr{}},
+		EndElement{Name{"", "br"}},
+		StartElement{Name{"", "br"}, []Attr{}},
+		EndElement{Name{"", "br"}},
+	}
+
+	d := NewDecoder(strings.NewReader(testInputHTMLAutoClose))
+	d.Strict = false
+	d.AutoClose = HTMLAutoClose
+	d.Entity = HTMLEntity
+	var haveTokens []Token
+	for {
+		tok, err := d.Token()
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+			t.Fatalf("unexpected error: %v", err)
+		}
+		haveTokens = append(haveTokens, CopyToken(tok))
+	}
+	if len(haveTokens) != len(wantTokens) {
+		t.Errorf("tokens count mismatch: have %d, want %d", len(haveTokens), len(wantTokens))
+	}
+	for i, want := range wantTokens {
+		if i >= len(haveTokens) {
+			t.Errorf("token[%d] expected %#v, have no token", i, want)
+		} else {
+			have := haveTokens[i]
+			if !reflect.DeepEqual(have, want) {
+				t.Errorf("token[%d] mismatch:\nhave: %#v\nwant: %#v", i, have, want)
+			}
+		}
 	}
 }


### PR DESCRIPTION
## Summary

- Replace the vendored `encoding/xml` fork with the current head of golang/go PR #48641 (`ydnar/go@a79fce77`, rebased on Go master 2024-10-28), previously pinned at an older `f68da8a` based on Go 1.17.
- Brings in ~4 years of stdlib `encoding/xml` fixes, including CVE-2022-30633 (unmarshal depth limit) and several panic fixes in `DecodeElement` and marshaling of embedded substructs.
- Preserves the local customization that skips escaping tab and newline in `CharData` byte content (needed for some DASHSchema test content) — reapplied to `EscapeText`/`escapeText` and the matching test case.
- Still compatible with Go 1.23 (no `go.mod` bump needed; the new code uses `reflect.TypeFor` and the builtin `min`, both available in Go 1.22+).

## Test plan

- [x] `go test ./...` passes against Go 1.26 toolchain
- [x] `go test ./...` passes against Go 1.23.0 toolchain (`GOTOOLCHAIN=go1.23.0`)
- [x] `TestDecodeEncodeMPDs` in `mpd/` round-trips all MPDs in `testdata/` without structural diffs
- [x] Pre-commit hooks (golangci-lint, go-unit-tests, trailing whitespace) pass