### PR TITLE
fix: alternativeMPD clip and earliestResolutionTimeOffset serialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `AlternativeMPDReplaceEventType.Clip` is now a `*bool` (default `true`) so that
+  `clip="false"` can be serialized. With a plain `bool` + `omitempty` the `false`
+  value was dropped and conforming clients applied the schema default (`true`),
+  i.e. the opposite of the intent.
+
+### Fixed
+
+- `AlternativeMPDEventType.EarliestResolutionTimeOffset` now renders in plain
+  decimal notation instead of scientific notation (e.g. `5400000` rather than
+  `5.4e+06`) by using the `FloatInf64` type.
+
 ## [0.15.0] - 2026-06-05
 
 ### Added

--- a/mpd/alternative_mpd_test.go
+++ b/mpd/alternative_mpd_test.go
@@ -1,0 +1,63 @@
+package mpd_test
+
+import (
+	"strings"
+	"testing"
+
+	m "github.com/Eyevinn/dash-mpd/mpd"
+	"github.com/stretchr/testify/require"
+)
+
+// buildAltReplaceMPD builds a minimal dynamic MPD with a single Alternative-MPD Replace event.
+// The earliestResolutionTimeOffset is 5400000 (60s * 90000), the value that previously
+// triggered scientific-notation rendering.
+func buildAltReplaceMPD(clip *bool) *m.MPD {
+	mpd := m.NewMPD(m.DYNAMIC_TYPE)
+	p := m.NewPeriod()
+	p.EventStreams = []*m.EventStreamType{{
+		SchemeIdUri: "urn:mpeg:dash:event:alternativeMPD:replace:2025",
+		Timescale:   m.Ptr(uint32(90000)),
+		Events: []*m.EventType{{
+			PresentationTime: 2700000,
+			Id:               m.Ptr(uint64(1)),
+			ReplacePresentation: &m.AlternativeMPDReplaceEventType{
+				Clip: clip,
+				AlternativeMPDEventType: &m.AlternativeMPDEventType{
+					Uri:                          "http://example.com/ad.mpd",
+					EarliestResolutionTimeOffset: 5400000,
+					MaxDuration:                  1350000,
+				},
+			},
+		}},
+	}}
+	mpd.AppendPeriod(p)
+	return mpd
+}
+
+// TestAlternativeMPDReplaceClipRendering verifies that @clip is a *bool so that clip="false"
+// can be rendered. With a plain bool+omitempty, clip="false" was silently dropped and a
+// conforming client then applied the schema default (true) — the opposite of the intent.
+func TestAlternativeMPDReplaceClipRendering(t *testing.T) {
+	out, err := buildAltReplaceMPD(m.Ptr(false)).WriteToString("  ", false)
+	require.NoError(t, err)
+	require.Contains(t, out, `clip="false"`)
+
+	out, err = buildAltReplaceMPD(m.Ptr(true)).WriteToString("  ", false)
+	require.NoError(t, err)
+	require.Contains(t, out, `clip="true"`)
+
+	// nil => attribute omitted, so a conforming client applies the default (true).
+	out, err = buildAltReplaceMPD(nil).WriteToString("  ", false)
+	require.NoError(t, err)
+	require.NotContains(t, out, "clip=")
+}
+
+// TestEarliestResolutionTimeOffsetFixedNotation verifies that the (large) xs:double
+// earliestResolutionTimeOffset renders in plain decimal, not scientific notation
+// (60s * 90000 = 5400000 previously rendered as "5.4e+06").
+func TestEarliestResolutionTimeOffsetFixedNotation(t *testing.T) {
+	out, err := buildAltReplaceMPD(m.Ptr(true)).WriteToString("  ", false)
+	require.NoError(t, err)
+	require.Contains(t, out, `earliestResolutionTimeOffset="5400000"`)
+	require.NotContains(t, strings.ToLower(out), "e+0")
+}

--- a/mpd/mpd.go
+++ b/mpd/mpd.go
@@ -991,7 +991,7 @@ type ClientDataReportingType struct {
 // AlternativeMPDEventType is Alternative MPD event
 type AlternativeMPDEventType struct {
 	Uri                          string            `xml:"uri,attr"`
-	EarliestResolutionTimeOffset float64           `xml:"earliestResolutionTimeOffset,attr,omitempty"`
+	EarliestResolutionTimeOffset FloatInf64        `xml:"earliestResolutionTimeOffset,attr,omitempty"`
 	MaxDuration                  uint64            `xml:"maxDuration,attr,omitempty"`
 	ExecuteOnce                  bool              `xml:"executeOnce,attr,omitempty"`
 	NoJump                       int32             `xml:"noJump,attr,omitempty"`
@@ -1002,7 +1002,7 @@ type AlternativeMPDEventType struct {
 // AlternativeMPDReplaceEventType is Alternative MPD Replacement Event
 type AlternativeMPDReplaceEventType struct {
 	ReturnOffset    uint64 `xml:"returnOffset,attr,omitempty"`
-	Clip            bool   `xml:"clip,attr,omitempty"`
+	Clip            *bool  `xml:"clip,attr"` // default = true; pointer so clip="false" can be rendered
 	StartWithOffset bool   `xml:"startWithOffset,attr,omitempty"`
 	*AlternativeMPDEventType
 }


### PR DESCRIPTION
## What

Two serialization fixes to the DASH Ed.6 Alternative-MPD event types, found while building Server-Guided Ad Insertion on top of dash-mpd (livesim2):

1. **`AlternativeMPDReplaceEventType.Clip` is now `*bool`** (default `true`).
   The schema declares `@clip` as `xs:boolean` with `default="true"`. With a plain `bool` + `omitempty`, setting `Clip=false` produced **no** `clip` attribute at all, so a conforming client applied the schema default (`true`) — the opposite of the author's intent. A `*bool` lets `clip="false"` be rendered explicitly; `nil` still omits the attribute (client applies the default `true`). This follows the existing `*bool // default = true` pattern in the library (e.g. `Valid`, `InAllPeriods`).

2. **`AlternativeMPDEventType.EarliestResolutionTimeOffset` is now `FloatInf64`** instead of `float64`.
   This `xs:double` is typically `seconds * timescale` (e.g. `60 * 90000 = 5400000`), which the default float marshaling rendered in scientific notation (`5.4e+06`). `FloatInf64.MarshalXMLAttr` already formats with `strconv.FormatFloat(f, 'f', -1, 64)`, so the value now renders as `5400000`, matching the normative Annex G examples.

## Breaking change

`Clip` changes from `bool` to `*bool`. Callers that set it must use a pointer, e.g. `Clip: Ptr(true)`, or leave it `nil` for the default (`true`).

## Tests

Adds `mpd/alternative_mpd_test.go` covering `clip="false"` / `clip="true"` / omitted, and the decimal rendering of `earliestResolutionTimeOffset`. Existing example round-trip tests are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
