### PR TITLE
docs: v0.15.1 CHANGELOG update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.1] - 2026-06-07
+
 ### Changed
 
 - `AlternativeMPDReplaceEventType.Clip` is now a `*bool` (default `true`) so that
@@ -251,7 +253,8 @@ Lots of convenience functions to create MPDs
 - Tests with well-known MPDs
 - Tweaked XML library to support namespaces
 
-[Unreleased]: https://github.com/Eyevinn/dash-mpd/compare/v0.15.0...HEAD
+[Unreleased]: https://github.com/Eyevinn/dash-mpd/compare/v0.15.1...HEAD
+[0.15.1]: https://github.com/Eyevinn/dash-mpd/compare/v0.15.0...v0.15.1
 [0.15.0]: https://github.com/Eyevinn/dash-mpd/compare/v0.14.1...v0.15.0
 [0.14.1]: https://github.com/Eyevinn/dash-mpd/compare/v0.14.0...v0.14.1
 [0.14.0]: https://github.com/Eyevinn/dash-mpd/compare/v0.13.0...v0.14.0


### PR DESCRIPTION
### Changed

- `AlternativeMPDReplaceEventType.Clip` is now a `*bool` (default `true`) so that
  `clip="false"` can be serialized. With a plain `bool` + `omitempty` the `false`
  value was dropped and conforming clients applied the schema default (`true`),
  i.e. the opposite of the intent.

### Fixed

- `AlternativeMPDEventType.EarliestResolutionTimeOffset` now renders in plain
  decimal notation instead of scientific notation (e.g. `5400000` rather than
  `5.4e+06`) by using the `FloatInf64` type.