### PR TITLE
SCTE-35 splice information signalling in EventType

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- SCTE-35 splice information signalling on `EventType` per ANSI/SCTE 35
+  2023r2: new `Signal` (SCTE 214-1 wrapper) and `SpliceInfoSection`
+  (direct-under-Event) fields, all six splice commands and six splice
+  descriptors, plus `Binary`, `Ext` and `anyAttribute` extensibility.
+- SCTE-35 namespace pass-through: the URI seen on unmarshal
+  (`http://www.scte.org/schemas/35` or the legacy `…/35/2016`) is replayed
+  verbatim on marshal.
+
 ## [0.15.1] - 2026-06-07
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -44,6 +44,52 @@ needed. The main modifications made were:
 * Change names to plural for all subelement slices, e.g. Periods instead of Period
 * Add ContentProtection elements and corresponding name spaces
 
+## SCTE-35
+
+DASH events carrying SCTE-35 splice information sections are supported with
+types defined in `mpd/scte35.go`, mapped from
+[`scte_35_20230713.xsd`](https://schemas.scte.org/35/) (ANSI/SCTE 35 2023r2).
+The `<Signal>` wrapper element specified by SCTE 214-1 is exposed as
+`EventType.Signal` and the alternative direct form (SCTE-35
+`SpliceInfoSection` placed straight under `Event`, as emitted by AWS
+MediaTailor and others) is exposed as `EventType.SpliceInfoSection`. Use the
+`(*EventType).SpliceInfo` helper to read either form uniformly.
+
+Two SCTE-35 namespace URIs are seen in the wild for the same schema:
+
+* `http://www.scte.org/schemas/35` — the canonical URI, declared as
+  `targetNamespace` by every XSD since 2020 (constant `mpd.SCTE35Namespace`).
+* `http://www.scte.org/schemas/35/2016` — a legacy URI still produced by a
+  large fraction of packagers (constant `mpd.SCTE35Namespace2016`).
+
+Each SCTE-35 type embeds an unnamed `XMLName xml.Name` field. On unmarshal the
+namespace URI is captured from the input document; on marshal it is replayed
+verbatim. An unmarshal/marshal round trip therefore preserves whichever URI
+the source manifest used — including the legacy 2016 variant. This is a
+deliberate exception to the "output names are fixed, and may differ from the
+input names" limitation listed below: SCTE-35 namespaces are passed through.
+
+A fresh value should be built via the `New*` constructors (`mpd.NewSignal`,
+`mpd.NewSpliceInfoSection`, `mpd.NewTimeSignal`, …) so that `XMLName` is set
+to the canonical URI by default. Bypassing them with a struct literal is
+legal but the resulting element will fall back to the Go type name when
+marshaled.
+
+```go
+sig := mpd.NewSignal()
+sis := mpd.NewSpliceInfoSection()
+tier := uint16(4095)
+sis.Tier = &tier
+sis.TimeSignal = mpd.NewTimeSignal()
+ptsTime := uint64(7835775000)
+sis.TimeSignal.SpliceTime = mpd.NewSpliceTime()
+sis.TimeSignal.SpliceTime.PtsTime = &ptsTime
+sig.SpliceInfoSection = sis
+event.Signal = sig
+```
+
+A representative set of round-trip fixtures lives in `mpd/testdata/scte35/`.
+
 ## XML handling
 
 The handling of XML name spaces in the Go standard library `encoding/xml` is incomplete,

--- a/mpd/mpd.go
+++ b/mpd/mpd.go
@@ -183,6 +183,14 @@ type EventStreamType struct {
 
 // EventType is Event. This has settings mixed="true" in the schema, so it can either
 // have charData or child elements or both.
+//
+// The Signal and SpliceInfoSection fields plug SCTE-35 messages into the DASH
+// MPD <xs:any namespace="##other"> extension slot of EventType. Both forms are
+// observed in the wild: Signal is the wrapper specified by SCTE 214-1 (used by
+// Unified Streaming, Broadpeak, etc.); SpliceInfoSection direct is produced by
+// AWS MediaTailor and others, valid because SpliceInfoSection is a global
+// element in the SCTE-35 XSD. Use (*EventType).SpliceInfo for a uniform
+// accessor that returns whichever is populated.
 type EventType struct {
 	XMLName              xml.Name                        `xml:"Event"`
 	PresentationTime     uint64                          `xml:"presentationTime,attr"` // default is 0
@@ -198,6 +206,8 @@ type EventType struct {
 	ReplacePresentation  *AlternativeMPDReplaceEventType `xml:"ReplacePresentation"`
 	SupplementalProperty []*DescriptorType               `xml:"SupplementalProperty"`
 	EssentialProperty    []*DescriptorType               `xml:"EssentialProperty"`
+	Signal               *SignalType                     `xml:"Signal,omitempty"`            // SCTE-35 Signal wrapper (SCTE 214-1)
+	SpliceInfoSection    *SpliceInfoSectionType          `xml:"SpliceInfoSection,omitempty"` // SCTE-35 SpliceInfoSection, direct form
 }
 
 // SelectionInfoType is SelectionInfo

--- a/mpd/mpd_test.go
+++ b/mpd/mpd_test.go
@@ -28,6 +28,7 @@ func TestDecodeEncodeMPDs(t *testing.T) {
 		"testdata/livesim",
 		"testdata/hbbtv",
 		"testdata/other",
+		"testdata/scte35",
 	}
 	for _, testDir := range testDirs {
 		fsys := os.DirFS(testDir)

--- a/mpd/scte35.go
+++ b/mpd/scte35.go
@@ -1,0 +1,575 @@
+package mpd
+
+import (
+	"github.com/Eyevinn/dash-mpd/xml"
+)
+
+// SCTE-35 (ANSI/SCTE 35 2023r2) splice information signalling for DASH MPD events.
+//
+// This file maps the SCTE-35 XML representation onto Go structs. The schema
+// source is https://schemas.scte.org/35/scte_35_20230713.xsd (version 20230713,
+// matching the ANSI/SCTE 35 2023r2 specification). The <Signal> wrapper element
+// is defined by SCTE 214-1 (MPEG-DASH carriage); the SCTE-35 XSD itself defines
+// it only as an xsd:group, with <SpliceInfoSection> and <Binary> as the two
+// global elements that may appear directly inside a DASH <Event>.
+//
+// # Namespace handling
+//
+// Two namespace URIs are seen in the wild for the same schema:
+//
+//   - "http://www.scte.org/schemas/35"      (canonical, declared as
+//     targetNamespace by all XSDs since 2020)
+//   - "http://www.scte.org/schemas/35/2016" (legacy, still produced by a
+//     significant fraction of packagers)
+//
+// The schema content is identical between the two URIs. Each SCTE-35 type in
+// this file therefore carries its namespace URI in an untagged XMLName field.
+// On unmarshal the URI is captured from the input document; on marshal it is
+// replayed verbatim. As a result an unmarshal/marshal round trip preserves
+// whichever URI the source manifest used.
+//
+// # Constructors
+//
+// A freshly built Signal/SpliceInfoSection/etc. value should be created via the
+// New* helpers in this file. They populate XMLName with the canonical SCTE-35
+// URI so that a newly constructed value marshals as a proper SCTE-35 element.
+// A bare struct literal works too but the resulting element will be emitted
+// without an xmlns="..." declaration, inheriting the surrounding DASH namespace
+// — typically not what you want.
+//
+// # Two carriage forms inside <Event>
+//
+//	<Event ...>
+//	  <Signal xmlns="http://www.scte.org/schemas/35">
+//	    <SpliceInfoSection ...>...</SpliceInfoSection>
+//	  </Signal>
+//	</Event>
+//
+// is the form prescribed by SCTE 214-1 and produced by Unified Streaming,
+// Broadpeak and similar packagers. AWS MediaTailor and a few others emit the
+// SpliceInfoSection directly:
+//
+//	<Event ...>
+//	  <scte35:SpliceInfoSection xmlns:scte35="http://www.scte.org/schemas/35" ...>...</scte35:SpliceInfoSection>
+//	</Event>
+//
+// Both forms are valid: SCTE-35 declares SpliceInfoSection as a global element
+// and the DASH MPD XSD's EventType has an <xs:any namespace="##other"
+// processContents="lax"/> extension slot. EventType exposes them through two
+// fields — Signal and SpliceInfoSection — see (*EventType).SpliceInfo for a
+// uniform accessor.
+
+// SCTE-35 namespace URIs.
+const (
+	// SCTE35Namespace is the canonical SCTE-35 XML namespace, declared as
+	// targetNamespace by every XSD revision since 2020.
+	SCTE35Namespace = "http://www.scte.org/schemas/35"
+	// SCTE35Namespace2016 is the legacy URI still produced by a large
+	// fraction of real-world packagers. Schema content is identical; the
+	// types here capture whichever URI is present in the input.
+	SCTE35Namespace2016 = "http://www.scte.org/schemas/35/2016"
+)
+
+// EventStream@schemeIdUri values for SCTE-35, defined by SCTE 214-1.
+const (
+	// SCTE35SchemeIdXML carries an XML representation of the SCTE-35
+	// message: a <Signal> containing either <SpliceInfoSection> or
+	// <Binary>, or one of those directly under <Event>.
+	SCTE35SchemeIdXML = "urn:scte:scte35:2013:xml"
+	// SCTE35SchemeIdXMLBin restricts the XML form to <Signal><Binary>...
+	SCTE35SchemeIdXMLBin = "urn:scte:scte35:2014:xml+bin"
+	// SCTE35SchemeIdBin is the raw binary form used for inband (emsg)
+	// signalling, never carried in an MPD event.
+	SCTE35SchemeIdBin = "urn:scte:scte35:2013:bin"
+)
+
+// Selected segmentation_type_id values from Table 23 of ANSI/SCTE 35 2023r2.
+// Values not listed here (custom or rare) are still valid; segmentationTypeId
+// on SegmentationDescriptorType accepts any uint8.
+const (
+	SegTypeNotIndicated                                uint8 = 0x00
+	SegTypeContentIdentification                       uint8 = 0x01
+	SegTypeProgramStart                                uint8 = 0x10
+	SegTypeProgramEnd                                  uint8 = 0x11
+	SegTypeProgramEarlyTermination                     uint8 = 0x12
+	SegTypeProgramBreakaway                            uint8 = 0x13
+	SegTypeProgramResumption                           uint8 = 0x14
+	SegTypeProgramRunoverPlanned                       uint8 = 0x15
+	SegTypeProgramRunoverUnplanned                     uint8 = 0x16
+	SegTypeProgramOverlapStart                         uint8 = 0x17
+	SegTypeProgramBlackoutOverride                     uint8 = 0x18
+	SegTypeProgramJoin                                 uint8 = 0x19
+	SegTypeChapterStart                                uint8 = 0x20
+	SegTypeChapterEnd                                  uint8 = 0x21
+	SegTypeBreakStart                                  uint8 = 0x22
+	SegTypeBreakEnd                                    uint8 = 0x23
+	SegTypeOpeningCreditStart                          uint8 = 0x24
+	SegTypeOpeningCreditEnd                            uint8 = 0x25
+	SegTypeClosingCreditStart                          uint8 = 0x26
+	SegTypeClosingCreditEnd                            uint8 = 0x27
+	SegTypeProviderAdvertisementStart                  uint8 = 0x30
+	SegTypeProviderAdvertisementEnd                    uint8 = 0x31
+	SegTypeDistributorAdvertisementStart               uint8 = 0x32
+	SegTypeDistributorAdvertisementEnd                 uint8 = 0x33
+	SegTypeProviderPlacementOpportunityStart           uint8 = 0x34
+	SegTypeProviderPlacementOpportunityEnd             uint8 = 0x35
+	SegTypeDistributorPlacementOpportunityStart        uint8 = 0x36
+	SegTypeDistributorPlacementOpportunityEnd          uint8 = 0x37
+	SegTypeProviderOverlayPlacementOpportunityStart    uint8 = 0x38
+	SegTypeProviderOverlayPlacementOpportunityEnd      uint8 = 0x39
+	SegTypeDistributorOverlayPlacementOpportunityStart uint8 = 0x3A
+	SegTypeDistributorOverlayPlacementOpportunityEnd   uint8 = 0x3B
+	SegTypeProviderPromoStart                          uint8 = 0x3C
+	SegTypeProviderPromoEnd                            uint8 = 0x3D
+	SegTypeDistributorPromoStart                       uint8 = 0x3E
+	SegTypeDistributorPromoEnd                         uint8 = 0x3F
+	SegTypeUnscheduledEventStart                       uint8 = 0x40
+	SegTypeUnscheduledEventEnd                         uint8 = 0x41
+	SegTypeAlternateContentOpportunityStart            uint8 = 0x42
+	SegTypeAlternateContentOpportunityEnd              uint8 = 0x43
+	SegTypeProviderAdBlockStart                        uint8 = 0x44
+	SegTypeProviderAdBlockEnd                          uint8 = 0x45
+	SegTypeDistributorAdBlockStart                     uint8 = 0x46
+	SegTypeDistributorAdBlockEnd                       uint8 = 0x47
+	SegTypeNetworkStart                                uint8 = 0x50
+	SegTypeNetworkEnd                                  uint8 = 0x51
+)
+
+// SignalType is the <Signal> wrapper element specified by SCTE 214-1 for
+// carrying an SCTE-35 message inside a DASH <Event>. It contains exactly one
+// of SpliceInfoSection (parsed XML form) or Binary (base64 of the binary
+// splice_info_section); see ANSI/SCTE 35 2023r2 section 12.
+//
+// XMLName preserves the namespace URI as seen in the input document. Use
+// NewSignal to construct a fresh value with the canonical URI.
+type SignalType struct {
+	XMLName           xml.Name
+	SpliceInfoSection *SpliceInfoSectionType `xml:"SpliceInfoSection,omitempty"`
+	Binary            *BinaryType            `xml:"Binary,omitempty"`
+}
+
+// SpliceInfoSectionType maps the SpliceInfoSection element of clause 9.6 of
+// ANSI/SCTE 35 2023r2. The XSD declares an xsd:choice between SpliceNull,
+// SpliceSchedule, SpliceInsert, TimeSignal, BandwidthReservation and
+// PrivateCommand — exactly one of those fields should be non-nil in a valid
+// message. The descriptor slices implement the trailing xsd:choice
+// maxOccurs="unbounded"; ordering between descriptor kinds is not preserved on
+// re-marshal (see limitation #3 of the package README).
+type SpliceInfoSectionType struct {
+	XMLName                 xml.Name
+	SapType                 *uint8                        `xml:"sapType,attr,omitempty"` // default 3
+	PreRollMilliSeconds     uint32                        `xml:"preRollMilliSeconds,attr,omitempty"`
+	PtsAdjustment           uint64                        `xml:"ptsAdjustment,attr,omitempty"`
+	ProtocolVersion         *uint8                        `xml:"protocolVersion,attr,omitempty"` // fixed 0
+	Tier                    *uint16                       `xml:"tier,attr,omitempty"`
+	AnyAttrs                []xml.Attr                    `xml:",any,attr"`
+	Ext                     *ExtType                      `xml:"Ext,omitempty"`
+	EncryptedPacket         *EncryptedPacketType          `xml:"EncryptedPacket,omitempty"`
+	SpliceNull              *SpliceNullType               `xml:"SpliceNull,omitempty"`
+	SpliceSchedule          *SpliceScheduleType           `xml:"SpliceSchedule,omitempty"`
+	SpliceInsert            *SpliceInsertType             `xml:"SpliceInsert,omitempty"`
+	TimeSignal              *TimeSignalType               `xml:"TimeSignal,omitempty"`
+	BandwidthReservation    *BandwidthReservationType     `xml:"BandwidthReservation,omitempty"`
+	PrivateCommand          *PrivateCommandType           `xml:"PrivateCommand,omitempty"`
+	AvailDescriptors        []*AvailDescriptorType        `xml:"AvailDescriptor"`
+	DTMFDescriptors         []*DTMFDescriptorType         `xml:"DTMFDescriptor"`
+	SegmentationDescriptors []*SegmentationDescriptorType `xml:"SegmentationDescriptor"`
+	TimeDescriptors         []*TimeDescriptorType         `xml:"TimeDescriptor"`
+	AudioDescriptors        []*AudioDescriptorType        `xml:"AudioDescriptor"`
+	PrivateDescriptors      []*PrivateDescriptorType      `xml:"PrivateDescriptor"`
+}
+
+// BinaryType is the <Binary> element used by the urn:scte:scte35:2014:xml+bin
+// scheme and as one branch of the SCTE-35 Signal group. Value is the base64
+// encoding of the raw splice_info_section bytes.
+type BinaryType struct {
+	XMLName    xml.Name
+	SignalType string `xml:"signalType,attr,omitempty"` // default "SpliceInfoSection"; "private:..." also allowed
+	Value      string `xml:",chardata"`
+}
+
+// EncryptedPacketType is the EncryptedPacket child of SpliceInfoSection. The
+// SCTE-35 XSD declares both attributes as required.
+type EncryptedPacketType struct {
+	XMLName             xml.Name
+	EncryptionAlgorithm uint8      `xml:"encryptionAlgorithm,attr"`
+	CwIndex             uint8      `xml:"cwIndex,attr"`
+	AnyAttrs            []xml.Attr `xml:",any,attr"`
+	Ext                 *ExtType   `xml:"Ext,omitempty"`
+}
+
+// SpliceNullType is the splice_null() command. Carries no data of its own.
+type SpliceNullType struct {
+	XMLName xml.Name
+	Ext     *ExtType `xml:"Ext,omitempty"`
+}
+
+// SpliceScheduleType is the splice_schedule() command. It contains 0..255
+// scheduled events, each with UTC splice times (xsd:dateTime).
+type SpliceScheduleType struct {
+	XMLName xml.Name
+	Ext     *ExtType                   `xml:"Ext,omitempty"`
+	Events  []*SpliceScheduleEventType `xml:"Event"`
+}
+
+// SpliceScheduleEventType is a single <Event> inside <SpliceSchedule>. The
+// Program / Components choice mirrors the XSD; valid messages set exactly one.
+type SpliceScheduleEventType struct {
+	XMLName                    xml.Name
+	SpliceEventId              *uint32                        `xml:"spliceEventId,attr,omitempty"`
+	EventIdComplianceFlag      *bool                          `xml:"eventIdComplianceFlag,attr,omitempty"`
+	SpliceEventCancelIndicator *bool                          `xml:"spliceEventCancelIndicator,attr,omitempty"` // default 0
+	OutOfNetworkIndicator      *bool                          `xml:"outOfNetworkIndicator,attr,omitempty"`
+	UniqueProgramId            *uint16                        `xml:"uniqueProgramId,attr,omitempty"`
+	AvailNum                   *uint8                         `xml:"availNum,attr,omitempty"`
+	AvailsExpected             *uint8                         `xml:"availsExpected,attr,omitempty"`
+	AnyAttrs                   []xml.Attr                     `xml:",any,attr"`
+	Ext                        *ExtType                       `xml:"Ext,omitempty"`
+	Program                    *SpliceScheduleProgramType     `xml:"Program,omitempty"`
+	Components                 []*SpliceScheduleComponentType `xml:"Component"`
+	BreakDuration              *BreakDurationType             `xml:"BreakDuration,omitempty"`
+}
+
+// SpliceScheduleProgramType is the program-mode <Program> inside a scheduled
+// event. The UTC splice time is required.
+type SpliceScheduleProgramType struct {
+	XMLName       xml.Name
+	UtcSpliceTime DateTime   `xml:"utcSpliceTime,attr"`
+	AnyAttrs      []xml.Attr `xml:",any,attr"`
+	Ext           *ExtType   `xml:"Ext,omitempty"`
+}
+
+// SpliceScheduleComponentType is the component-mode <Component> inside a
+// scheduled event. Both componentTag and utcSpliceTime are required.
+type SpliceScheduleComponentType struct {
+	XMLName       xml.Name
+	ComponentTag  uint8      `xml:"componentTag,attr"`
+	UtcSpliceTime DateTime   `xml:"utcSpliceTime,attr"`
+	AnyAttrs      []xml.Attr `xml:",any,attr"`
+	Ext           *ExtType   `xml:"Ext,omitempty"`
+}
+
+// SpliceInsertType is the splice_insert() command. The Program / Components
+// choice mirrors the XSD; valid messages set exactly one.
+type SpliceInsertType struct {
+	XMLName                    xml.Name
+	SpliceEventId              *uint32                      `xml:"spliceEventId,attr,omitempty"`
+	SpliceEventCancelIndicator *bool                        `xml:"spliceEventCancelIndicator,attr,omitempty"` // default 0
+	OutOfNetworkIndicator      *bool                        `xml:"outOfNetworkIndicator,attr,omitempty"`
+	SpliceImmediateFlag        *bool                        `xml:"spliceImmediateFlag,attr,omitempty"`
+	EventIdComplianceFlag      *bool                        `xml:"eventIdComplianceFlag,attr,omitempty"`
+	UniqueProgramId            *uint16                      `xml:"uniqueProgramId,attr,omitempty"`
+	AvailNum                   *uint8                       `xml:"availNum,attr,omitempty"`
+	AvailsExpected             *uint8                       `xml:"availsExpected,attr,omitempty"`
+	Ext                        *ExtType                     `xml:"Ext,omitempty"`
+	Program                    *SpliceInsertProgramType     `xml:"Program,omitempty"`
+	Components                 []*SpliceInsertComponentType `xml:"Component"`
+	BreakDuration              *BreakDurationType           `xml:"BreakDuration,omitempty"`
+}
+
+// SpliceInsertProgramType is the program-mode <Program> inside a splice
+// insert. SpliceTime is optional and absent when spliceImmediateFlag="true".
+type SpliceInsertProgramType struct {
+	XMLName    xml.Name
+	AnyAttrs   []xml.Attr      `xml:",any,attr"`
+	Ext        *ExtType        `xml:"Ext,omitempty"`
+	SpliceTime *SpliceTimeType `xml:"SpliceTime,omitempty"`
+}
+
+// SpliceInsertComponentType is the component-mode <Component> inside a splice
+// insert. componentTag is required; SpliceTime is optional.
+type SpliceInsertComponentType struct {
+	XMLName      xml.Name
+	ComponentTag uint8           `xml:"componentTag,attr"`
+	AnyAttrs     []xml.Attr      `xml:",any,attr"`
+	Ext          *ExtType        `xml:"Ext,omitempty"`
+	SpliceTime   *SpliceTimeType `xml:"SpliceTime,omitempty"`
+}
+
+// TimeSignalType is the time_signal() command. SpliceTime is required.
+type TimeSignalType struct {
+	XMLName    xml.Name
+	Ext        *ExtType        `xml:"Ext,omitempty"`
+	SpliceTime *SpliceTimeType `xml:"SpliceTime"`
+}
+
+// BandwidthReservationType is the bandwidth_reservation() command. It carries
+// no data of its own.
+type BandwidthReservationType struct {
+	XMLName xml.Name
+	Ext     *ExtType `xml:"Ext,omitempty"`
+}
+
+// PrivateCommandType is the private_command() command. identifier is the
+// 32-bit owner ID; PrivateBytes carries the owner-defined payload as hex.
+type PrivateCommandType struct {
+	XMLName      xml.Name
+	Identifier   uint32   `xml:"identifier,attr"`
+	Ext          *ExtType `xml:"Ext,omitempty"`
+	PrivateBytes string   `xml:"PrivateBytes,omitempty"` // xsd:hexBinary
+}
+
+// SpliceTimeType is the splice_time() structure carrying a PTS-domain time.
+// ptsTime is optional (absent indicates a time-specified-flag of 0 in the
+// binary form).
+type SpliceTimeType struct {
+	XMLName  xml.Name
+	PtsTime  *uint64    `xml:"ptsTime,attr,omitempty"`
+	AnyAttrs []xml.Attr `xml:",any,attr"`
+	Ext      *ExtType   `xml:"Ext,omitempty"`
+}
+
+// BreakDurationType is the break_duration() structure shared by SpliceInsert
+// and SpliceScheduleEvent. Both attributes are required.
+type BreakDurationType struct {
+	XMLName    xml.Name
+	AutoReturn bool       `xml:"autoReturn,attr"`
+	Duration   uint64     `xml:"duration,attr"`
+	AnyAttrs   []xml.Attr `xml:",any,attr"`
+	Ext        *ExtType   `xml:"Ext,omitempty"`
+}
+
+// AvailDescriptorType is the avail_descriptor() splice descriptor.
+type AvailDescriptorType struct {
+	XMLName         xml.Name
+	ProviderAvailId uint32     `xml:"providerAvailId,attr"`
+	AnyAttrs        []xml.Attr `xml:",any,attr"`
+	Ext             *ExtType   `xml:"Ext,omitempty"`
+}
+
+// DTMFDescriptorType is the DTMF_descriptor() splice descriptor.
+type DTMFDescriptorType struct {
+	XMLName  xml.Name
+	Preroll  *uint8     `xml:"preroll,attr,omitempty"`
+	Chars    string     `xml:"chars,attr,omitempty"` // restricted to [0-9#*]+
+	AnyAttrs []xml.Attr `xml:",any,attr"`
+	Ext      *ExtType   `xml:"Ext,omitempty"`
+}
+
+// SegmentationDescriptorType is the segmentation_descriptor() splice
+// descriptor — the workhorse for ad insertion signalling. See clause 10.3.3
+// of ANSI/SCTE 35 2023r2 and Table 23 for segmentationTypeId values
+// (constants SegType* are defined in this package).
+type SegmentationDescriptorType struct {
+	XMLName                          xml.Name
+	SegmentationEventId              *uint32 `xml:"segmentationEventId,attr,omitempty"`
+	SegmentationEventCancelIndicator *bool   `xml:"segmentationEventCancelIndicator,attr,omitempty"` // default 0
+	// SegmentationEventIdComplianceIndicator captures the corresponding XSD
+	// attribute. The 2020+ XSDs declare it with the literal name
+	// "segmentationEventIdComplianceIndicatorbute" — a known SCTE-35 schema
+	// typo. Real-world manifests use the corrected name without the trailing
+	// "bute" and the XSD typo is treated as errata; we match the corrected
+	// name for interop and document the discrepancy here.
+	SegmentationEventIdComplianceIndicator *bool                                  `xml:"segmentationEventIdComplianceIndicator,attr,omitempty"`
+	SegmentationDuration                   *uint64                                `xml:"segmentationDuration,attr,omitempty"` // < 2^40
+	SegmentationTypeId                     *uint8                                 `xml:"segmentationTypeId,attr,omitempty"`
+	SegmentNum                             *uint8                                 `xml:"segmentNum,attr,omitempty"`
+	SegmentsExpected                       *uint8                                 `xml:"segmentsExpected,attr,omitempty"`
+	SubSegmentNum                          *uint8                                 `xml:"subSegmentNum,attr,omitempty"`
+	SubSegmentsExpected                    *uint8                                 `xml:"subSegmentsExpected,attr,omitempty"`
+	AnyAttrs                               []xml.Attr                             `xml:",any,attr"`
+	Ext                                    *ExtType                               `xml:"Ext,omitempty"`
+	DeliveryRestrictions                   *DeliveryRestrictionsType              `xml:"DeliveryRestrictions,omitempty"`
+	SegmentationUpids                      []*SegmentationUpidType                `xml:"SegmentationUpid"`
+	Components                             []*SegmentationDescriptorComponentType `xml:"Component"`
+}
+
+// DeliveryRestrictionsType is the <DeliveryRestrictions> child element of
+// SegmentationDescriptor. All four attributes are XSD-required.
+type DeliveryRestrictionsType struct {
+	XMLName                xml.Name
+	WebDeliveryAllowedFlag bool       `xml:"webDeliveryAllowedFlag,attr"`
+	NoRegionalBlackoutFlag bool       `xml:"noRegionalBlackoutFlag,attr"`
+	ArchiveAllowedFlag     bool       `xml:"archiveAllowedFlag,attr"`
+	DeviceRestrictions     uint8      `xml:"deviceRestrictions,attr"` // 0..3, see Table 21
+	AnyAttrs               []xml.Attr `xml:",any,attr"`
+	Ext                    *ExtType   `xml:"Ext,omitempty"`
+}
+
+// SegmentationUpidType is the <SegmentationUpid> child of
+// SegmentationDescriptor. The element body is an xsd:token whose meaning is
+// dictated by the SegmentationUpidType attribute and the optional Format
+// attribute.
+//
+// Real-world manifests sometimes carry a "segmentationUpidLength" attribute
+// that was removed from the 2023 XSD; AnyAttrs preserves it through round
+// trips.
+type SegmentationUpidType struct {
+	XMLName                xml.Name
+	SegmentationUpidType   *uint8     `xml:"segmentationUpidType,attr,omitempty"`
+	FormatIdentifier       *uint32    `xml:"formatIdentifier,attr,omitempty"`
+	SegmentationUpidFormat string     `xml:"segmentationUpidFormat,attr,omitempty"` // text|hexbinary|base-64|private:...
+	AnyAttrs               []xml.Attr `xml:",any,attr"`
+	Value                  string     `xml:",chardata"`
+}
+
+// SegmentationDescriptorComponentType is the <Component> child of
+// SegmentationDescriptor (distinct from the splice-time Component variants).
+type SegmentationDescriptorComponentType struct {
+	XMLName      xml.Name
+	ComponentTag uint8      `xml:"componentTag,attr"`
+	PtsOffset    uint64     `xml:"ptsOffset,attr"` // PTSType
+	AnyAttrs     []xml.Attr `xml:",any,attr"`
+	Ext          *ExtType   `xml:"Ext,omitempty"`
+}
+
+// TimeDescriptorType is the time_descriptor() splice descriptor (TAI offset).
+type TimeDescriptorType struct {
+	XMLName    xml.Name
+	TaiSeconds *uint64    `xml:"taiSeconds,attr,omitempty"` // < 2^48
+	TaiNs      *uint32    `xml:"taiNs,attr,omitempty"`
+	UtcOffset  *uint16    `xml:"utcOffset,attr,omitempty"`
+	AnyAttrs   []xml.Attr `xml:",any,attr"`
+	Ext        *ExtType   `xml:"Ext,omitempty"`
+}
+
+// AudioDescriptorType is the audio_descriptor() splice descriptor. It carries
+// 1..15 AudioChannel children describing the audio service streams. Note that
+// the SCTE-35 XSD spells these attributes with mixed case (BitStreamMode,
+// NumChannels, FullSrvcAudio).
+type AudioDescriptorType struct {
+	XMLName       xml.Name
+	AnyAttrs      []xml.Attr          `xml:",any,attr"`
+	Ext           *ExtType            `xml:"Ext,omitempty"`
+	AudioChannels []*AudioChannelType `xml:"AudioChannel"`
+}
+
+// AudioChannelType is a single <AudioChannel> entry inside an
+// AudioDescriptor. ISOCode, BitStreamMode, NumChannels and FullSrvcAudio are
+// XSD-required; componentTag is optional (0xFF means "use PMT order").
+type AudioChannelType struct {
+	XMLName       xml.Name
+	ISOCode       string     `xml:"ISOCode,attr"` // xsd:language
+	BitStreamMode uint8      `xml:"BitStreamMode,attr"`
+	NumChannels   uint8      `xml:"NumChannels,attr"`
+	FullSrvcAudio uint8      `xml:"FullSrvcAudio,attr"` // 0 or 1
+	ComponentTag  *uint8     `xml:"componentTag,attr,omitempty"`
+	AnyAttrs      []xml.Attr `xml:",any,attr"`
+	Ext           *ExtType   `xml:"Ext,omitempty"`
+}
+
+// PrivateDescriptorType is the private_descriptor() catch-all owned by the
+// identifier value (per SMPTE Registration Authority).
+type PrivateDescriptorType struct {
+	XMLName       xml.Name
+	DescriptorTag uint8      `xml:"descriptorTag,attr"`
+	Identifier    uint32     `xml:"identifier,attr"`
+	AnyAttrs      []xml.Attr `xml:",any,attr"`
+	Ext           *ExtType   `xml:"Ext,omitempty"`
+	PrivateBytes  string     `xml:"PrivateBytes,omitempty"` // xsd:hexBinary
+}
+
+// ExtType is the SCTE-35 extensibility element. It can appear inside almost
+// every SCTE-35 type and accepts arbitrary attributes and child elements
+// (xs:any processContents="lax"). InnerXML captures the raw nested XML so
+// extension content survives an unmarshal/marshal round trip; AnyAttrs
+// captures arbitrary attributes likewise.
+type ExtType struct {
+	XMLName  xml.Name
+	AnyAttrs []xml.Attr `xml:",any,attr"`
+	InnerXML string     `xml:",innerxml"`
+}
+
+// canonicalSCTE35Name returns an xml.Name with the canonical SCTE-35 namespace
+// and the given local name. Used by the New* constructors below.
+func canonicalSCTE35Name(local string) xml.Name {
+	return xml.Name{Space: SCTE35Namespace, Local: local}
+}
+
+// NewSignal returns a Signal with XMLName preset to the canonical SCTE-35
+// namespace. Populate SpliceInfoSection or Binary (not both) before marshal.
+func NewSignal() *SignalType {
+	return &SignalType{XMLName: canonicalSCTE35Name("Signal")}
+}
+
+// NewSpliceInfoSection returns a SpliceInfoSection with XMLName preset to the
+// canonical SCTE-35 namespace.
+func NewSpliceInfoSection() *SpliceInfoSectionType {
+	return &SpliceInfoSectionType{XMLName: canonicalSCTE35Name("SpliceInfoSection")}
+}
+
+// NewBinary returns a Binary element (the urn:scte:scte35:2014:xml+bin form)
+// with XMLName preset to the canonical SCTE-35 namespace and Value set to v.
+func NewBinary(v string) *BinaryType {
+	return &BinaryType{XMLName: canonicalSCTE35Name("Binary"), Value: v}
+}
+
+// NewSpliceNull returns a SpliceNull command in the canonical namespace.
+func NewSpliceNull() *SpliceNullType {
+	return &SpliceNullType{XMLName: canonicalSCTE35Name("SpliceNull")}
+}
+
+// NewSpliceSchedule returns a SpliceSchedule command in the canonical namespace.
+func NewSpliceSchedule() *SpliceScheduleType {
+	return &SpliceScheduleType{XMLName: canonicalSCTE35Name("SpliceSchedule")}
+}
+
+// NewSpliceInsert returns a SpliceInsert command in the canonical namespace.
+func NewSpliceInsert() *SpliceInsertType {
+	return &SpliceInsertType{XMLName: canonicalSCTE35Name("SpliceInsert")}
+}
+
+// NewTimeSignal returns a TimeSignal command in the canonical namespace.
+func NewTimeSignal() *TimeSignalType {
+	return &TimeSignalType{XMLName: canonicalSCTE35Name("TimeSignal")}
+}
+
+// NewBandwidthReservation returns a BandwidthReservation command in the
+// canonical namespace.
+func NewBandwidthReservation() *BandwidthReservationType {
+	return &BandwidthReservationType{XMLName: canonicalSCTE35Name("BandwidthReservation")}
+}
+
+// NewPrivateCommand returns a PrivateCommand with the given owner identifier
+// and XMLName preset to the canonical SCTE-35 namespace.
+func NewPrivateCommand(identifier uint32) *PrivateCommandType {
+	return &PrivateCommandType{XMLName: canonicalSCTE35Name("PrivateCommand"), Identifier: identifier}
+}
+
+// NewSpliceTime returns a SpliceTime element in the canonical namespace.
+func NewSpliceTime() *SpliceTimeType {
+	return &SpliceTimeType{XMLName: canonicalSCTE35Name("SpliceTime")}
+}
+
+// NewBreakDuration returns a BreakDuration element in the canonical namespace
+// with the given autoReturn and duration values.
+func NewBreakDuration(autoReturn bool, duration uint64) *BreakDurationType {
+	return &BreakDurationType{
+		XMLName:    canonicalSCTE35Name("BreakDuration"),
+		AutoReturn: autoReturn,
+		Duration:   duration,
+	}
+}
+
+// NewSegmentationDescriptor returns a SegmentationDescriptor in the canonical
+// namespace.
+func NewSegmentationDescriptor() *SegmentationDescriptorType {
+	return &SegmentationDescriptorType{XMLName: canonicalSCTE35Name("SegmentationDescriptor")}
+}
+
+// NewSegmentationUpid returns a SegmentationUpid in the canonical namespace
+// with the given value.
+func NewSegmentationUpid(value string) *SegmentationUpidType {
+	return &SegmentationUpidType{XMLName: canonicalSCTE35Name("SegmentationUpid"), Value: value}
+}
+
+// IsSCTE35 reports whether es carries SCTE-35 events (i.e. its SchemeIdUri
+// is one of the URIs defined in SCTE 214-1 for SCTE-35 carriage in DASH).
+func (es *EventStreamType) IsSCTE35() bool {
+	switch string(es.SchemeIdUri) {
+	case SCTE35SchemeIdXML, SCTE35SchemeIdXMLBin, SCTE35SchemeIdBin:
+		return true
+	}
+	return false
+}
+
+// SpliceInfo returns the SCTE-35 SpliceInfoSection of the event, whether it
+// is wrapped in a Signal element (per SCTE 214-1) or attached directly to
+// Event (per AWS MediaTailor and other tooling). Returns nil if neither is
+// present.
+func (e *EventType) SpliceInfo() *SpliceInfoSectionType {
+	if e.Signal != nil && e.Signal.SpliceInfoSection != nil {
+		return e.Signal.SpliceInfoSection
+	}
+	return e.SpliceInfoSection
+}

--- a/mpd/scte35_test.go
+++ b/mpd/scte35_test.go
@@ -1,0 +1,340 @@
+package mpd_test
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/Eyevinn/dash-mpd/mpd"
+	"github.com/Eyevinn/dash-mpd/xml"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSCTE35NamespacePassThrough confirms that the SCTE-35 namespace URI
+// observed at unmarshal time is replayed verbatim at marshal time, for both
+// the canonical "http://www.scte.org/schemas/35" URI and the legacy 2016
+// variant used in much of the install base.
+func TestSCTE35NamespacePassThrough(t *testing.T) {
+	cases := []struct {
+		file     string
+		wantNS   string
+		wantLine string
+	}{
+		{
+			file:     "testdata/scte35/time_signal_segmentation.mpd",
+			wantNS:   mpd.SCTE35Namespace,
+			wantLine: `<Signal xmlns="http://www.scte.org/schemas/35">`,
+		},
+		{
+			file:     "testdata/scte35/signal_binary_xmlbin.mpd",
+			wantNS:   mpd.SCTE35Namespace2016,
+			wantLine: `<Signal xmlns="http://www.scte.org/schemas/35/2016">`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.file, func(t *testing.T) {
+			data, err := os.ReadFile(tc.file)
+			require.NoError(t, err)
+			m, err := mpd.MPDFromBytes(data)
+			require.NoError(t, err)
+
+			ev := m.Periods[0].EventStreams[0].Events[0]
+			require.NotNil(t, ev.Signal, "expected Signal to be populated")
+			require.Equal(t, tc.wantNS, ev.Signal.XMLName.Space, "namespace not captured from input")
+
+			out, err := xml.MarshalIndent(m, "", "  ")
+			require.NoError(t, err)
+			require.Contains(t, string(out), tc.wantLine,
+				"marshal output does not preserve input namespace")
+		})
+	}
+}
+
+// TestSCTE35SpliceInfoSectionDirectFormPassThrough is the equivalent of
+// TestSCTE35NamespacePassThrough for the "no Signal wrapper" form
+// (SpliceInfoSection placed directly under Event, AWS MediaTailor style).
+func TestSCTE35SpliceInfoSectionDirectFormPassThrough(t *testing.T) {
+	data, err := os.ReadFile("testdata/scte35/direct_splice_info_section.mpd")
+	require.NoError(t, err)
+	m, err := mpd.MPDFromBytes(data)
+	require.NoError(t, err)
+
+	ev := m.Periods[0].EventStreams[0].Events[0]
+	require.Nil(t, ev.Signal, "Signal must be nil for the direct form")
+	require.NotNil(t, ev.SpliceInfoSection, "SpliceInfoSection must be populated for the direct form")
+	require.Equal(t, mpd.SCTE35Namespace, ev.SpliceInfoSection.XMLName.Space)
+
+	out, err := xml.MarshalIndent(m, "", "  ")
+	require.NoError(t, err)
+	s := string(out)
+	require.Contains(t, s, `<SpliceInfoSection`,
+		"SpliceInfoSection element must be emitted")
+	require.Contains(t, s, mpd.SCTE35Namespace,
+		"direct SpliceInfoSection should round-trip with its namespace preserved")
+}
+
+// TestSCTE35SpliceInfo verifies the (*EventType).SpliceInfo helper returns
+// the section from whichever form (wrapped or direct) is populated.
+func TestSCTE35SpliceInfo(t *testing.T) {
+	t.Run("wrapped in Signal", func(t *testing.T) {
+		data, err := os.ReadFile("testdata/scte35/time_signal_segmentation.mpd")
+		require.NoError(t, err)
+		m, err := mpd.MPDFromBytes(data)
+		require.NoError(t, err)
+
+		sis := m.Periods[0].EventStreams[0].Events[0].SpliceInfo()
+		require.NotNil(t, sis)
+		require.NotNil(t, sis.TimeSignal)
+	})
+	t.Run("direct under Event", func(t *testing.T) {
+		data, err := os.ReadFile("testdata/scte35/direct_splice_info_section.mpd")
+		require.NoError(t, err)
+		m, err := mpd.MPDFromBytes(data)
+		require.NoError(t, err)
+
+		sis := m.Periods[0].EventStreams[0].Events[0].SpliceInfo()
+		require.NotNil(t, sis)
+		require.NotNil(t, sis.TimeSignal)
+	})
+	t.Run("neither set", func(t *testing.T) {
+		ev := &mpd.EventType{}
+		require.Nil(t, ev.SpliceInfo())
+	})
+}
+
+// TestSCTE35ConstructorsUseCanonicalNamespace asserts that the New* helpers
+// in mpd/scte35.go produce values whose XMLName carries the canonical
+// SCTE-35 URI, so that programmatic construction marshals to a proper
+// SCTE-35 element by default.
+func TestSCTE35ConstructorsUseCanonicalNamespace(t *testing.T) {
+	cases := []struct {
+		name  string
+		got   xml.Name
+		local string
+	}{
+		{"Signal", mpd.NewSignal().XMLName, "Signal"},
+		{"SpliceInfoSection", mpd.NewSpliceInfoSection().XMLName, "SpliceInfoSection"},
+		{"Binary", mpd.NewBinary("").XMLName, "Binary"},
+		{"SpliceNull", mpd.NewSpliceNull().XMLName, "SpliceNull"},
+		{"SpliceSchedule", mpd.NewSpliceSchedule().XMLName, "SpliceSchedule"},
+		{"SpliceInsert", mpd.NewSpliceInsert().XMLName, "SpliceInsert"},
+		{"TimeSignal", mpd.NewTimeSignal().XMLName, "TimeSignal"},
+		{"BandwidthReservation", mpd.NewBandwidthReservation().XMLName, "BandwidthReservation"},
+		{"PrivateCommand", mpd.NewPrivateCommand(0).XMLName, "PrivateCommand"},
+		{"SpliceTime", mpd.NewSpliceTime().XMLName, "SpliceTime"},
+		{"BreakDuration", mpd.NewBreakDuration(false, 0).XMLName, "BreakDuration"},
+		{"SegmentationDescriptor", mpd.NewSegmentationDescriptor().XMLName, "SegmentationDescriptor"},
+		{"SegmentationUpid", mpd.NewSegmentationUpid("").XMLName, "SegmentationUpid"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, mpd.SCTE35Namespace, tc.got.Space)
+			require.Equal(t, tc.local, tc.got.Local)
+		})
+	}
+}
+
+// TestEventStreamIsSCTE35 covers the schemeIdUri detection helper.
+func TestEventStreamIsSCTE35(t *testing.T) {
+	cases := []struct {
+		scheme string
+		want   bool
+	}{
+		{mpd.SCTE35SchemeIdXML, true},
+		{mpd.SCTE35SchemeIdXMLBin, true},
+		{mpd.SCTE35SchemeIdBin, true},
+		{"urn:mpeg:dash:event:2012", false},
+		{"", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.scheme, func(t *testing.T) {
+			es := &mpd.EventStreamType{SchemeIdUri: mpd.AnyURI(tc.scheme)}
+			require.Equal(t, tc.want, es.IsSCTE35())
+		})
+	}
+}
+
+// TestSCTE35ProgrammaticRoundTrip builds a Signal/SpliceInfoSection/TimeSignal
+// programmatically, marshals it, unmarshals back and checks key fields. Also
+// asserts that the canonical SCTE-35 namespace is used in the output, even
+// when wrapped inside a DASH MPD whose default namespace is the DASH one.
+func TestSCTE35ProgrammaticRoundTrip(t *testing.T) {
+	m := mpd.NewMPD(mpd.DYNAMIC_TYPE)
+	m.Profiles = mpd.PROFILE_LIVE
+	m.AvailabilityStartTime = mpd.DateTime("2024-01-01T00:00:00Z")
+	m.MinBufferTime = mpd.Seconds2DurPtr(4)
+	m.MinimumUpdatePeriod = mpd.Seconds2DurPtr(2)
+
+	p := mpd.NewPeriod()
+	p.Id = "1"
+	p.Start = mpd.Seconds2DurPtr(0)
+	m.AppendPeriod(p)
+
+	ts := uint32(90000)
+	es := &mpd.EventStreamType{
+		SchemeIdUri: mpd.AnyURI(mpd.SCTE35SchemeIdXML),
+		Timescale:   &ts,
+	}
+	p.EventStreams = append(p.EventStreams, es)
+
+	sig := mpd.NewSignal()
+	sis := mpd.NewSpliceInfoSection()
+	tier := uint16(4095)
+	sis.Tier = &tier
+
+	st := mpd.NewSpliceTime()
+	pts := uint64(123456789)
+	st.PtsTime = &pts
+	sis.TimeSignal = &mpd.TimeSignalType{
+		XMLName:    xml.Name{Space: mpd.SCTE35Namespace, Local: "TimeSignal"},
+		SpliceTime: st,
+	}
+
+	upid := mpd.NewSegmentationUpid("PROVIDERX")
+	upidType := uint8(9)
+	upid.SegmentationUpidType = &upidType
+
+	segDesc := mpd.NewSegmentationDescriptor()
+	eventID := uint32(42)
+	dur := uint64(2700000)
+	segType := mpd.SegTypeProviderPlacementOpportunityStart
+	segNum := uint8(1)
+	expected := uint8(1)
+	segDesc.SegmentationEventId = &eventID
+	segDesc.SegmentationDuration = &dur
+	segDesc.SegmentationTypeId = &segType
+	segDesc.SegmentNum = &segNum
+	segDesc.SegmentsExpected = &expected
+	segDesc.SegmentationUpids = []*mpd.SegmentationUpidType{upid}
+	sis.SegmentationDescriptors = []*mpd.SegmentationDescriptorType{segDesc}
+
+	sig.SpliceInfoSection = sis
+
+	id := uint64(7)
+	ev := &mpd.EventType{
+		PresentationTime: 900000,
+		Duration:         2700000,
+		Id:               &id,
+		Signal:           sig,
+	}
+	es.Events = append(es.Events, ev)
+
+	out, err := xml.MarshalIndent(m, "", "  ")
+	require.NoError(t, err)
+	s := string(out)
+	require.Contains(t, s, `<Signal xmlns="http://www.scte.org/schemas/35">`)
+	require.Contains(t, s, `<TimeSignal>`)
+	require.Contains(t, s, `<SpliceTime ptsTime="123456789">`)
+	require.Contains(t, s, `<SegmentationDescriptor`)
+	require.Contains(t, s, `segmentationTypeId="52"`)
+	require.Contains(t, s, `<SegmentationUpid segmentationUpidType="9">PROVIDERX</SegmentationUpid>`)
+	require.NotContains(t, s, `xmlns="http://www.scte.org/schemas/35"`+"\n",
+		"namespace should be declared once, on the Signal element")
+
+	// Round-trip back: parse the marshal output and assert structure.
+	rt, err := mpd.MPDFromBytes(out)
+	require.NoError(t, err)
+	rtEv := rt.Periods[0].EventStreams[0].Events[0]
+	require.NotNil(t, rtEv.Signal)
+	require.NotNil(t, rtEv.Signal.SpliceInfoSection)
+	require.NotNil(t, rtEv.Signal.SpliceInfoSection.TimeSignal)
+	require.NotNil(t, rtEv.Signal.SpliceInfoSection.TimeSignal.SpliceTime)
+	require.NotNil(t, rtEv.Signal.SpliceInfoSection.TimeSignal.SpliceTime.PtsTime)
+	require.Equal(t, uint64(123456789), *rtEv.Signal.SpliceInfoSection.TimeSignal.SpliceTime.PtsTime)
+	require.Len(t, rtEv.Signal.SpliceInfoSection.SegmentationDescriptors, 1)
+	rtSeg := rtEv.Signal.SpliceInfoSection.SegmentationDescriptors[0]
+	require.Equal(t, uint8(52), *rtSeg.SegmentationTypeId)
+	require.Len(t, rtSeg.SegmentationUpids, 1)
+	require.Equal(t, "PROVIDERX", rtSeg.SegmentationUpids[0].Value)
+}
+
+// TestSCTE35BareConstructionFallsBackToTypeName documents the behaviour when
+// users build a SignalType with a struct literal and forget to set XMLName:
+// since the xml fork falls through to reflect.Type.Name() when no XMLName
+// and no parent field tag give a local name, the element is emitted with the
+// raw Go type name ("SignalType"). Always prefer NewSignal() (and the other
+// New* helpers) to avoid this surprise.
+func TestSCTE35BareConstructionFallsBackToTypeName(t *testing.T) {
+	bare := &mpd.SignalType{Binary: mpd.NewBinary("AA==")}
+	out, err := xml.Marshal(bare)
+	require.NoError(t, err)
+	s := string(out)
+	require.True(t, strings.HasPrefix(s, "<SignalType>"),
+		"bare Signal falls back to the Go type name; got %q", s)
+
+	// With the constructor, the element is named "Signal" and carries the
+	// canonical SCTE-35 namespace.
+	good := mpd.NewSignal()
+	good.Binary = mpd.NewBinary("AA==")
+	outGood, err := xml.Marshal(good)
+	require.NoError(t, err)
+	require.True(t, strings.HasPrefix(string(outGood),
+		`<Signal xmlns="http://www.scte.org/schemas/35">`),
+		"NewSignal() should produce a proper Signal element; got %q", outGood)
+}
+
+// TestSCTE35SpliceInsertFields covers SpliceInsert with the Program/SpliceTime
+// path including BreakDuration; uses the splice_insert.mpd fixture.
+func TestSCTE35SpliceInsertFields(t *testing.T) {
+	data, err := os.ReadFile("testdata/scte35/splice_insert.mpd")
+	require.NoError(t, err)
+	m, err := mpd.MPDFromBytes(data)
+	require.NoError(t, err)
+
+	sis := m.Periods[0].EventStreams[0].Events[0].SpliceInfo()
+	require.NotNil(t, sis)
+	si := sis.SpliceInsert
+	require.NotNil(t, si)
+	require.Equal(t, uint32(4157), *si.SpliceEventId)
+	require.True(t, *si.OutOfNetworkIndicator)
+	require.False(t, *si.SpliceImmediateFlag)
+	require.NotNil(t, si.Program)
+	require.NotNil(t, si.Program.SpliceTime)
+	require.Equal(t, uint64(2346545680), *si.Program.SpliceTime.PtsTime)
+	require.NotNil(t, si.BreakDuration)
+	require.True(t, si.BreakDuration.AutoReturn)
+	require.Equal(t, uint64(2699769), si.BreakDuration.Duration)
+}
+
+// TestSCTE35BinaryRoundTrip covers the xml+bin form (Signal + Binary) end to
+// end on the signal_binary_xmlbin.mpd fixture, including the legacy 2016
+// namespace.
+func TestSCTE35BinaryRoundTrip(t *testing.T) {
+	data, err := os.ReadFile("testdata/scte35/signal_binary_xmlbin.mpd")
+	require.NoError(t, err)
+	m, err := mpd.MPDFromBytes(data)
+	require.NoError(t, err)
+
+	ev := m.Periods[0].EventStreams[0].Events[0]
+	require.NotNil(t, ev.Signal)
+	require.NotNil(t, ev.Signal.Binary)
+	require.Nil(t, ev.Signal.SpliceInfoSection)
+	require.Contains(t, ev.Signal.Binary.Value, "/DBI")
+
+	out, err := xml.MarshalIndent(m, "", "  ")
+	require.NoError(t, err)
+	s := string(out)
+	require.Contains(t, s, mpd.SCTE35Namespace2016)
+	require.NotContains(t, s, `xmlns="http://www.scte.org/schemas/35">`+"\n",
+		"canonical namespace must not appear when input is in the legacy URI")
+}
+
+// TestSCTE35DeliveryRestrictions verifies the DeliveryRestrictions sub-element
+// of SegmentationDescriptor is parsed with all four required boolean/uint
+// attributes.
+func TestSCTE35DeliveryRestrictions(t *testing.T) {
+	data, err := os.ReadFile("testdata/scte35/delivery_restrictions.mpd")
+	require.NoError(t, err)
+	m, err := mpd.MPDFromBytes(data)
+	require.NoError(t, err)
+
+	sis := m.Periods[0].EventStreams[0].Events[0].SpliceInfo()
+	require.NotNil(t, sis)
+	require.Len(t, sis.SegmentationDescriptors, 1)
+	dr := sis.SegmentationDescriptors[0].DeliveryRestrictions
+	require.NotNil(t, dr)
+	require.True(t, dr.WebDeliveryAllowedFlag)
+	require.True(t, dr.NoRegionalBlackoutFlag)
+	require.True(t, dr.ArchiveAllowedFlag)
+	require.Equal(t, uint8(3), dr.DeviceRestrictions)
+}

--- a/mpd/testdata/scte35/README.md
+++ b/mpd/testdata/scte35/README.md
@@ -1,0 +1,36 @@
+# SCTE-35 test fixtures
+
+DASH MPDs carrying SCTE-35 splice information sections, used by
+`TestDecodeEncodeMPDs` to validate the unmarshal/marshal round-trip
+of the types in `mpd/scte35.go`.
+
+The schema source is [`scte_35_20230713.xsd`][xsd] (ANSI/SCTE 35
+2023r2), retrieved from <https://schemas.scte.org/35/>. The carriage
+in DASH events (the `<Signal>` wrapper element and the
+`urn:scte:scte35:2013:xml` / `urn:scte:scte35:2014:xml+bin` schemeIdUri
+values) is defined by [SCTE 214-1][214-1].
+
+Each fixture is hand-written and verified to round-trip
+unchanged through the package after a single marshal pass.
+Durations are written in their canonical form
+(e.g. `PT48H10M2.036S`, not `PT173402.036S`) and DASH attributes use
+the order produced by the marshaller; both are existing constraints
+of the round-trip test that the SCTE-35 fixtures inherit.
+
+| File | What it covers |
+|---|---|
+| `time_signal_segmentation.mpd` | `<Signal>` + `TimeSignal` + `SegmentationDescriptor` + `SegmentationUpid` (the canonical ad-marker form) |
+| `splice_insert.mpd` | `SpliceInsert` with `Program`/`SpliceTime` and `BreakDuration` |
+| `splice_insert_immediate.mpd` | `SpliceInsert` with `spliceImmediateFlag="true"` (no `SpliceTime`) |
+| `signal_binary_xmlbin.mpd` | `<Signal>` + `Binary` (`urn:scte:scte35:2014:xml+bin` form) using the **legacy** `http://www.scte.org/schemas/35/2016` namespace, demonstrating round-trip pass-through of the namespace URI |
+| `direct_splice_info_section.mpd` | `SpliceInfoSection` placed directly inside `<Event>` without a `<Signal>` wrapper (AWS MediaTailor style) |
+| `delivery_restrictions.mpd` | `SegmentationDescriptor` with `DeliveryRestrictions` and a hex-binary `SegmentationUpid` |
+| `splice_null_heartbeat.mpd` | `SpliceNull` heartbeat |
+| `splice_schedule.mpd` | `SpliceSchedule` with a single scheduled `Event` |
+| `private_command.mpd` | `PrivateCommand` with `PrivateBytes` payload |
+| `time_descriptor.mpd` | `TimeSignal` accompanied by a `TimeDescriptor` (TAI) |
+| `audio_descriptor.mpd` | `AudioDescriptor` with two `AudioChannel` children |
+| `avail_dtmf_descriptors.mpd` | `SpliceInsert` accompanied by `AvailDescriptor` and `DTMFDescriptor` |
+
+[xsd]: https://schemas.scte.org/35/scte_35_20230713.xsd
+[214-1]: https://account.scte.org/standards/library/catalog/scte-214-1-mpeg-dash-for-ip-based-cable-services-part1-mpd-constraints-and-extensions/

--- a/mpd/testdata/scte35/audio_descriptor.mpd
+++ b/mpd/testdata/scte35/audio_descriptor.mpd
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<MPD xmlns="urn:mpeg:dash:schema:mpd:2011" profiles="urn:mpeg:dash:profile:isoff-live:2011" type="dynamic" availabilityStartTime="2024-01-01T00:00:00Z" minimumUpdatePeriod="PT2S" minBufferTime="PT4S">
+  <Period id="1" start="PT0S">
+    <EventStream timescale="90000" schemeIdUri="urn:scte:scte35:2013:xml">
+      <Event presentationTime="0" id="1">
+        <Signal xmlns="http://www.scte.org/schemas/35">
+          <SpliceInfoSection ptsAdjustment="0" tier="4095">
+            <TimeSignal>
+              <SpliceTime ptsTime="0"></SpliceTime>
+            </TimeSignal>
+            <AudioDescriptor>
+              <AudioChannel ISOCode="eng" BitStreamMode="0" NumChannels="2" FullSrvcAudio="1" componentTag="1"></AudioChannel>
+              <AudioChannel ISOCode="spa" BitStreamMode="0" NumChannels="2" FullSrvcAudio="1" componentTag="2"></AudioChannel>
+            </AudioDescriptor>
+          </SpliceInfoSection>
+        </Signal>
+      </Event>
+    </EventStream>
+    <AdaptationSet id="1" segmentAlignment="true" mimeType="video/mp4" startWithSAP="1">
+      <SegmentTemplate media="$Number$.mp4" initialization="init.mp4" timescale="90000"></SegmentTemplate>
+      <Representation id="1" bandwidth="500000" width="640" height="360" codecs="avc1.4D401F"></Representation>
+    </AdaptationSet>
+  </Period>
+</MPD>

--- a/mpd/testdata/scte35/avail_dtmf_descriptors.mpd
+++ b/mpd/testdata/scte35/avail_dtmf_descriptors.mpd
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<MPD xmlns="urn:mpeg:dash:schema:mpd:2011" profiles="urn:mpeg:dash:profile:isoff-live:2011" type="dynamic" availabilityStartTime="2024-01-01T00:00:00Z" minimumUpdatePeriod="PT2S" minBufferTime="PT4S">
+  <Period id="1" start="PT0S">
+    <EventStream timescale="90000" schemeIdUri="urn:scte:scte35:2013:xml">
+      <Event presentationTime="0" duration="2700000" id="1">
+        <Signal xmlns="http://www.scte.org/schemas/35">
+          <SpliceInfoSection ptsAdjustment="0" tier="4095">
+            <SpliceInsert spliceEventId="1" outOfNetworkIndicator="true" spliceImmediateFlag="false">
+              <Program>
+                <SpliceTime ptsTime="0"></SpliceTime>
+              </Program>
+              <BreakDuration autoReturn="true" duration="2700000"></BreakDuration>
+            </SpliceInsert>
+            <AvailDescriptor providerAvailId="42"></AvailDescriptor>
+            <DTMFDescriptor preroll="200" chars="*5"></DTMFDescriptor>
+          </SpliceInfoSection>
+        </Signal>
+      </Event>
+    </EventStream>
+    <AdaptationSet id="1" segmentAlignment="true" mimeType="video/mp4" startWithSAP="1">
+      <SegmentTemplate media="$Number$.mp4" initialization="init.mp4" timescale="90000"></SegmentTemplate>
+      <Representation id="1" bandwidth="500000" width="640" height="360" codecs="avc1.4D401F"></Representation>
+    </AdaptationSet>
+  </Period>
+</MPD>

--- a/mpd/testdata/scte35/delivery_restrictions.mpd
+++ b/mpd/testdata/scte35/delivery_restrictions.mpd
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<MPD xmlns="urn:mpeg:dash:schema:mpd:2011" profiles="urn:mpeg:dash:profile:isoff-live:2011" type="dynamic" availabilityStartTime="2024-01-01T00:00:00Z" minimumUpdatePeriod="PT2S" minBufferTime="PT4S">
+  <Period id="1" start="PT0S">
+    <EventStream timescale="90000" schemeIdUri="urn:scte:scte35:2013:xml">
+      <Event presentationTime="900000" duration="2700000" id="99">
+        <Signal xmlns="http://www.scte.org/schemas/35">
+          <SpliceInfoSection ptsAdjustment="0" tier="4095">
+            <TimeSignal>
+              <SpliceTime ptsTime="900000"></SpliceTime>
+            </TimeSignal>
+            <SegmentationDescriptor segmentationEventId="99" segmentationDuration="2700000" segmentationTypeId="52" segmentNum="1" segmentsExpected="1">
+              <DeliveryRestrictions webDeliveryAllowedFlag="true" noRegionalBlackoutFlag="true" archiveAllowedFlag="true" deviceRestrictions="3"></DeliveryRestrictions>
+              <SegmentationUpid segmentationUpidType="14" segmentationUpidFormat="hexbinary">012345</SegmentationUpid>
+            </SegmentationDescriptor>
+          </SpliceInfoSection>
+        </Signal>
+      </Event>
+    </EventStream>
+    <AdaptationSet id="1" segmentAlignment="true" mimeType="video/mp4" startWithSAP="1">
+      <SegmentTemplate media="$Number$.mp4" initialization="init.mp4" timescale="90000"></SegmentTemplate>
+      <Representation id="1" bandwidth="500000" width="640" height="360" codecs="avc1.4D401F"></Representation>
+    </AdaptationSet>
+  </Period>
+</MPD>

--- a/mpd/testdata/scte35/direct_splice_info_section.mpd
+++ b/mpd/testdata/scte35/direct_splice_info_section.mpd
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<MPD xmlns="urn:mpeg:dash:schema:mpd:2011" profiles="urn:mpeg:dash:profile:isoff-live:2011" type="dynamic" availabilityStartTime="2024-01-01T00:00:00Z" minimumUpdatePeriod="PT2S" minBufferTime="PT4S">
+  <Period id="46041" start="PT48H10M2.036S">
+    <EventStream timescale="90000" schemeIdUri="urn:scte:scte35:2013:xml">
+      <Event presentationTime="0" duration="9450000" id="99">
+        <SpliceInfoSection xmlns="http://www.scte.org/schemas/35" ptsAdjustment="183265" tier="4095">
+          <TimeSignal>
+            <SpliceTime ptsTime="7835775000"></SpliceTime>
+          </TimeSignal>
+          <SegmentationDescriptor segmentationEventId="99" segmentationEventCancelIndicator="false" segmentationDuration="9450000" segmentationTypeId="52" segmentNum="1" segmentsExpected="1">
+            <SegmentationUpid segmentationUpidType="8"></SegmentationUpid>
+          </SegmentationDescriptor>
+        </SpliceInfoSection>
+      </Event>
+    </EventStream>
+    <AdaptationSet id="1" segmentAlignment="true" mimeType="video/mp4" startWithSAP="1">
+      <SegmentTemplate media="$Number$.mp4" initialization="init.mp4" timescale="90000"></SegmentTemplate>
+      <Representation id="1" bandwidth="500000" width="640" height="360" codecs="avc1.4D401F"></Representation>
+    </AdaptationSet>
+  </Period>
+</MPD>

--- a/mpd/testdata/scte35/private_command.mpd
+++ b/mpd/testdata/scte35/private_command.mpd
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<MPD xmlns="urn:mpeg:dash:schema:mpd:2011" profiles="urn:mpeg:dash:profile:isoff-live:2011" type="dynamic" availabilityStartTime="2024-01-01T00:00:00Z" minimumUpdatePeriod="PT2S" minBufferTime="PT4S">
+  <Period id="1" start="PT0S">
+    <EventStream timescale="90000" schemeIdUri="urn:scte:scte35:2013:xml">
+      <Event presentationTime="0" id="0">
+        <Signal xmlns="http://www.scte.org/schemas/35">
+          <SpliceInfoSection ptsAdjustment="0" tier="4095">
+            <PrivateCommand identifier="1129661769">
+              <PrivateBytes>deadbeef</PrivateBytes>
+            </PrivateCommand>
+          </SpliceInfoSection>
+        </Signal>
+      </Event>
+    </EventStream>
+    <AdaptationSet id="1" segmentAlignment="true" mimeType="video/mp4" startWithSAP="1">
+      <SegmentTemplate media="$Number$.mp4" initialization="init.mp4" timescale="90000"></SegmentTemplate>
+      <Representation id="1" bandwidth="500000" width="640" height="360" codecs="avc1.4D401F"></Representation>
+    </AdaptationSet>
+  </Period>
+</MPD>

--- a/mpd/testdata/scte35/signal_binary_xmlbin.mpd
+++ b/mpd/testdata/scte35/signal_binary_xmlbin.mpd
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<MPD xmlns="urn:mpeg:dash:schema:mpd:2011" profiles="urn:mpeg:dash:profile:isoff-live:2011" type="dynamic" availabilityStartTime="2026-06-04T10:20:00Z" minimumUpdatePeriod="PT2S" minBufferTime="PT4S">
+  <Period id="1" start="PT0S">
+    <EventStream timescale="10000000" schemeIdUri="urn:scte:scte35:2014:xml+bin">
+      <Event presentationTime="89028119760" duration="12650" id="872416252">
+        <Signal xmlns="http://www.scte.org/schemas/35/2016">
+          <Binary>/DBIAAAAAAAAAP/wBQb+RPVwgAAyAjBDVUVJNAAD/H/AAAFbcVAMGlRWU1Q6ZnJhbmNlMl8yMDI2MDYwNF8xMDIwNAEBAADstgk/</Binary>
+        </Signal>
+      </Event>
+    </EventStream>
+    <AdaptationSet id="1" segmentAlignment="true" mimeType="video/mp4" startWithSAP="1">
+      <SegmentTemplate media="$Number$.mp4" initialization="init.mp4" timescale="90000"></SegmentTemplate>
+      <Representation id="1" bandwidth="500000" width="640" height="360" codecs="avc1.4D401F"></Representation>
+    </AdaptationSet>
+  </Period>
+</MPD>

--- a/mpd/testdata/scte35/splice_insert.mpd
+++ b/mpd/testdata/scte35/splice_insert.mpd
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<MPD xmlns="urn:mpeg:dash:schema:mpd:2011" profiles="urn:mpeg:dash:profile:isoff-live:2011" type="dynamic" availabilityStartTime="2024-01-01T00:00:00Z" minimumUpdatePeriod="PT2S" minBufferTime="PT4S">
+  <Period id="1" start="PT0S">
+    <EventStream timescale="90000" schemeIdUri="urn:scte:scte35:2013:xml">
+      <Event presentationTime="2346545680" duration="2699769" id="4157">
+        <Signal xmlns="http://www.scte.org/schemas/35">
+          <SpliceInfoSection ptsAdjustment="8586003992" tier="4095">
+            <SpliceInsert spliceEventId="4157" outOfNetworkIndicator="true" spliceImmediateFlag="false" uniqueProgramId="1" availNum="1" availsExpected="1">
+              <Program>
+                <SpliceTime ptsTime="2346545680"></SpliceTime>
+              </Program>
+              <BreakDuration autoReturn="true" duration="2699769"></BreakDuration>
+            </SpliceInsert>
+          </SpliceInfoSection>
+        </Signal>
+      </Event>
+    </EventStream>
+    <AdaptationSet id="1" segmentAlignment="true" mimeType="video/mp4" startWithSAP="1">
+      <SegmentTemplate media="$Number$.mp4" initialization="init.mp4" timescale="90000"></SegmentTemplate>
+      <Representation id="1" bandwidth="500000" width="640" height="360" codecs="avc1.4D401F"></Representation>
+    </AdaptationSet>
+  </Period>
+</MPD>

--- a/mpd/testdata/scte35/splice_insert_immediate.mpd
+++ b/mpd/testdata/scte35/splice_insert_immediate.mpd
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<MPD xmlns="urn:mpeg:dash:schema:mpd:2011" profiles="urn:mpeg:dash:profile:isoff-live:2011" type="dynamic" availabilityStartTime="2024-01-01T00:00:00Z" minimumUpdatePeriod="PT2S" minBufferTime="PT4S">
+  <Period id="1" start="PT0S">
+    <EventStream timescale="90000" schemeIdUri="urn:scte:scte35:2013:xml">
+      <Event presentationTime="0" duration="2700000" id="4158">
+        <Signal xmlns="http://www.scte.org/schemas/35">
+          <SpliceInfoSection>
+            <SpliceInsert spliceEventId="4158" outOfNetworkIndicator="true" spliceImmediateFlag="true">
+              <Program></Program>
+              <BreakDuration autoReturn="true" duration="2700000"></BreakDuration>
+            </SpliceInsert>
+          </SpliceInfoSection>
+        </Signal>
+      </Event>
+    </EventStream>
+    <AdaptationSet id="1" segmentAlignment="true" mimeType="video/mp4" startWithSAP="1">
+      <SegmentTemplate media="$Number$.mp4" initialization="init.mp4" timescale="90000"></SegmentTemplate>
+      <Representation id="1" bandwidth="500000" width="640" height="360" codecs="avc1.4D401F"></Representation>
+    </AdaptationSet>
+  </Period>
+</MPD>

--- a/mpd/testdata/scte35/splice_null_heartbeat.mpd
+++ b/mpd/testdata/scte35/splice_null_heartbeat.mpd
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<MPD xmlns="urn:mpeg:dash:schema:mpd:2011" profiles="urn:mpeg:dash:profile:isoff-live:2011" type="dynamic" availabilityStartTime="2024-01-01T00:00:00Z" minimumUpdatePeriod="PT2S" minBufferTime="PT4S">
+  <Period id="1" start="PT0S">
+    <EventStream timescale="90000" schemeIdUri="urn:scte:scte35:2013:xml">
+      <Event presentationTime="0" id="0">
+        <Signal xmlns="http://www.scte.org/schemas/35">
+          <SpliceInfoSection>
+            <SpliceNull></SpliceNull>
+          </SpliceInfoSection>
+        </Signal>
+      </Event>
+    </EventStream>
+    <AdaptationSet id="1" segmentAlignment="true" mimeType="video/mp4" startWithSAP="1">
+      <SegmentTemplate media="$Number$.mp4" initialization="init.mp4" timescale="90000"></SegmentTemplate>
+      <Representation id="1" bandwidth="500000" width="640" height="360" codecs="avc1.4D401F"></Representation>
+    </AdaptationSet>
+  </Period>
+</MPD>

--- a/mpd/testdata/scte35/splice_schedule.mpd
+++ b/mpd/testdata/scte35/splice_schedule.mpd
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<MPD xmlns="urn:mpeg:dash:schema:mpd:2011" profiles="urn:mpeg:dash:profile:isoff-live:2011" type="static" mediaPresentationDuration="PT1H" minBufferTime="PT4S">
+  <Period id="1">
+    <EventStream timescale="1" schemeIdUri="urn:scte:scte35:2013:xml">
+      <Event presentationTime="0" id="0">
+        <Signal xmlns="http://www.scte.org/schemas/35">
+          <SpliceInfoSection>
+            <SpliceSchedule>
+              <Event spliceEventId="1" outOfNetworkIndicator="true" uniqueProgramId="1" availNum="1" availsExpected="1">
+                <Program utcSpliceTime="2024-01-01T12:00:00Z"></Program>
+                <BreakDuration autoReturn="true" duration="2700000"></BreakDuration>
+              </Event>
+            </SpliceSchedule>
+          </SpliceInfoSection>
+        </Signal>
+      </Event>
+    </EventStream>
+    <AdaptationSet id="1" segmentAlignment="true" mimeType="video/mp4" startWithSAP="1">
+      <SegmentTemplate media="$Number$.mp4" initialization="init.mp4" timescale="90000"></SegmentTemplate>
+      <Representation id="1" bandwidth="500000" width="640" height="360" codecs="avc1.4D401F"></Representation>
+    </AdaptationSet>
+  </Period>
+</MPD>

--- a/mpd/testdata/scte35/time_descriptor.mpd
+++ b/mpd/testdata/scte35/time_descriptor.mpd
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<MPD xmlns="urn:mpeg:dash:schema:mpd:2011" profiles="urn:mpeg:dash:profile:isoff-live:2011" type="dynamic" availabilityStartTime="2024-01-01T00:00:00Z" minimumUpdatePeriod="PT2S" minBufferTime="PT4S">
+  <Period id="1" start="PT0S">
+    <EventStream timescale="90000" schemeIdUri="urn:scte:scte35:2013:xml">
+      <Event presentationTime="0" id="1">
+        <Signal xmlns="http://www.scte.org/schemas/35">
+          <SpliceInfoSection ptsAdjustment="0" tier="4095">
+            <TimeSignal>
+              <SpliceTime ptsTime="1234567890"></SpliceTime>
+            </TimeSignal>
+            <TimeDescriptor taiSeconds="1704067200" taiNs="0" utcOffset="37"></TimeDescriptor>
+          </SpliceInfoSection>
+        </Signal>
+      </Event>
+    </EventStream>
+    <AdaptationSet id="1" segmentAlignment="true" mimeType="video/mp4" startWithSAP="1">
+      <SegmentTemplate media="$Number$.mp4" initialization="init.mp4" timescale="90000"></SegmentTemplate>
+      <Representation id="1" bandwidth="500000" width="640" height="360" codecs="avc1.4D401F"></Representation>
+    </AdaptationSet>
+  </Period>
+</MPD>

--- a/mpd/testdata/scte35/time_signal_segmentation.mpd
+++ b/mpd/testdata/scte35/time_signal_segmentation.mpd
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<MPD xmlns="urn:mpeg:dash:schema:mpd:2011" profiles="urn:mpeg:dash:profile:isoff-live:2011" type="dynamic" availabilityStartTime="2024-01-01T00:00:00Z" minimumUpdatePeriod="PT2S" minBufferTime="PT4S">
+  <Period id="1" start="PT0S">
+    <EventStream timescale="90000" schemeIdUri="urn:scte:scte35:2013:xml">
+      <Event presentationTime="900000" duration="2700000" id="1">
+        <Signal xmlns="http://www.scte.org/schemas/35">
+          <SpliceInfoSection ptsAdjustment="0" tier="4095">
+            <TimeSignal>
+              <SpliceTime ptsTime="7835775000"></SpliceTime>
+            </TimeSignal>
+            <SegmentationDescriptor segmentationEventId="99" segmentationDuration="2700000" segmentationTypeId="52" segmentNum="1" segmentsExpected="1">
+              <SegmentationUpid segmentationUpidType="9">PROVIDERX</SegmentationUpid>
+            </SegmentationDescriptor>
+          </SpliceInfoSection>
+        </Signal>
+      </Event>
+    </EventStream>
+    <AdaptationSet id="1" segmentAlignment="true" mimeType="video/mp4" startWithSAP="1">
+      <SegmentTemplate media="video_$Number$.mp4" initialization="video.mp4" timescale="5994">
+        <SegmentTimeline>
+          <S t="0" d="12000" r="154"></S>
+        </SegmentTimeline>
+      </SegmentTemplate>
+      <Representation id="1" bandwidth="3000000" width="1280" height="720" codecs="avc1.4D401F"></Representation>
+    </AdaptationSet>
+  </Period>
+</MPD>


### PR DESCRIPTION
## What

Add `Signal` and `SpliceInfoSection` fields to `EventType`, with full type coverage for ANSI/SCTE 35 2023r2 splice information sections (XSD `scte_35_20230713.xsd`).

## Why

DASH events carrying SCTE-35 signalling appear under two bindings in the wild and both are now first-class:
- `<Signal>` wrapper specified by SCTE 214-1 — Unified Streaming, Broadpeak, …
- `<SpliceInfoSection>` directly under `<Event>` — AWS MediaTailor and others, valid because `SpliceInfoSection` is a global element in the SCTE-35 XSD
`(*EventType).SpliceInfo()` returns whichever the source manifest populated.

## Coverage

- Splice commands: `SpliceNull`, `SpliceSchedule`, `SpliceInsert`, `TimeSignal`, `BandwidthReservation`, `PrivateCommand`
- Splice descriptors: `Avail`, `DTMF`, `Segmentation`, `Time`, `Audio`, `Private`
- `Binary`, `Ext` and anyAttribute extensibility
- Exported constants: `SCTE35Namespace`, `SCTE35Namespace2016`, `SCTE35SchemeIdXML/XMLBin/Bin`, and the Table 23 segmentation type IDs

## XML namespace round-trip

Two URIs are seen in the wild for the same schema:
- `http://www.scte.org/schemas/35` — canonical, declared `targetNamespace` since 2020
- `http://www.scte.org/schemas/35/2016` — legacy, still produced by a large fraction of packagers
Each SCTE-35 type embeds an unnamed `XMLName xml.Name`: the URI seen on unmarshal is replayed verbatim on marshal, so a round trip preserves whichever the input used. Deliberate exception to the "output names are fixed" rule listed in the README, called out there explicitly. `New*` constructors default `XMLName` to the canonical URI for programmatic use.
