### PR TITLE
docs: remove retired Go Report Card badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 ![Test](https://github.com/Eyevinn/dash-mpd/workflows/Go/badge.svg)
 [![golangci-lint](https://github.com/Eyevinn/dash-mpd/actions/workflows/golangci-lint.yml/badge.svg)](https://github.com/Eyevinn/dash-mpd/actions/workflows/golangci-lint.yml)
 [![GoDoc](https://godoc.org/github.com/Eyevinn/dash-mpd?status.svg)](http://godoc.org/github.com/Eyevinn/dash-mpd)
-[![Go Report Card](https://goreportcard.com/badge/github.com/Eyevinn/dash-mpd)](https://goreportcard.com/report/github.com/Eyevinn/dash-mpd)
 [![license](https://img.shields.io/github/license/Eyevinn/dash-mpd.svg)](https://github.com/Eyevinn/dash-mpd/blob/master/LICENSE)
 
 # DASH-MPD - A complete MPEG-DASH MPD parser/writer


### PR DESCRIPTION
The Go Report Card widget has been retired, so this removes the badge from the README.