### PR TITLE
SCTE-214 supplemental codecs and asset identification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `supplementalCodecs` attributes on `RepresentationBaseType` (available on
   AdaptationSet, Representation and SubRepresentation), and `ContentIdentifier`
   elements on `DescriptorType` for UPID-based asset identification in
-  `AssetIdentifier` and `SupplementalProperty`.
+  `AssetIdentifier` and `SupplementalProperty`. The Go identifiers carry an
+  `SCTE214` prefix (`SCTE214SupplementalCodecs`, `SCTE214ContentIdentifiers`,
+  `SCTE214ContentIdentifierType`, ...) to keep the plain names free for future
+  DASH MPD schema updates.
 - Exported constants for the SCTE-214 namespaces (`SCTE214Namespace`,
   `SCTE214Namespace2021`) and the descriptor scheme URIs defined by the
   specification (`SCTE214SchemeId*`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- SCTE-214 MPD extensions per ANSI/SCTE 214-1 2024: `supplementalProfiles` and
+  `supplementalCodecs` attributes on `RepresentationBaseType` (available on
+  AdaptationSet, Representation and SubRepresentation), and `ContentIdentifier`
+  elements on `DescriptorType` for UPID-based asset identification in
+  `AssetIdentifier` and `SupplementalProperty`.
+- Exported constants for the SCTE-214 namespaces (`SCTE214Namespace`,
+  `SCTE214Namespace2021`) and the descriptor scheme URIs defined by the
+  specification (`SCTE214SchemeId*`).
+
 ## [0.16.0] - 2026-06-26
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -89,6 +89,42 @@ event.Signal = sig
 
 A representative set of round-trip fixtures lives in `mpd/testdata/scte35/`.
 
+## SCTE-214
+
+The MPD extensions defined by ANSI/SCTE 214-1 2024 (MPEG DASH for IP-Based
+Cable Services Part 1: MPD Constraints and Extensions) are supported with
+types and constants in `mpd/scte214.go`:
+
+* `supplementalProfiles` and `supplementalCodecs` attributes on
+  `RepresentationBaseType`, and thereby on AdaptationSet, Representation and
+  SubRepresentation. Both are space-separated lists, used e.g. for
+  backwards-compatible Dolby Vision and HDR10+ signalling.
+* `ContentIdentifier` elements on `DescriptorType` for UPID-based asset
+  identification inside `AssetIdentifier` and `SupplementalProperty`
+  descriptors with the `urn:scte:dash:asset-id:upid:2015` scheme.
+* The descriptor scheme URIs defined by the specification as
+  `SCTE214SchemeId*` constants.
+
+All extension elements and attributes belong to the
+`urn:scte:dash:scte214-extensions` namespace (`mpd.SCTE214Namespace`). The
+`scte214` prefix is emitted on marshal, declared on the carrying element; on
+unmarshal any prefix bound to the namespace URI is matched.
+
+```go
+rep := mpd.NewRepresentation()
+rep.Codecs = "hvc1.2.4.L120.b0"
+rep.SupplementalCodecs = "dvh1.08.03"
+rep.SupplementalProfiles = "db1p"
+
+asset := mpd.NewDescriptor(mpd.SCTE214SchemeIdAssetIdUpid, "", "")
+asset.ContentIdentifiers = []*mpd.ContentIdentifierType{
+    mpd.NewContentIdentifier("EIDR", "10.5240/EA73-79D7-1B2B-B378-3A73-M"),
+}
+period.AssetIdentifier = asset
+```
+
+A representative set of round-trip fixtures lives in `mpd/testdata/scte214/`.
+
 ## XML handling
 
 The handling of XML name spaces in the Go standard library `encoding/xml` is incomplete,

--- a/README.md
+++ b/README.md
@@ -95,13 +95,15 @@ The MPD extensions defined by ANSI/SCTE 214-1 2024 (MPEG DASH for IP-Based
 Cable Services Part 1: MPD Constraints and Extensions) are supported with
 types and constants in `mpd/scte214.go`:
 
-* `supplementalProfiles` and `supplementalCodecs` attributes on
+* `supplementalProfiles` and `supplementalCodecs` attributes
+  (`SCTE214SupplementalProfiles`, `SCTE214SupplementalCodecs`) on
   `RepresentationBaseType`, and thereby on AdaptationSet, Representation and
   SubRepresentation. Both are space-separated lists, used e.g. for
   backwards-compatible Dolby Vision and HDR10+ signalling.
-* `ContentIdentifier` elements on `DescriptorType` for UPID-based asset
-  identification inside `AssetIdentifier` and `SupplementalProperty`
-  descriptors with the `urn:scte:dash:asset-id:upid:2015` scheme.
+* `ContentIdentifier` elements (`SCTE214ContentIdentifiers`) on
+  `DescriptorType` for UPID-based asset identification inside
+  `AssetIdentifier` and `SupplementalProperty` descriptors with the
+  `urn:scte:dash:asset-id:upid:2015` scheme.
 * The descriptor scheme URIs defined by the specification as
   `SCTE214SchemeId*` constants.
 
@@ -113,12 +115,12 @@ unmarshal any prefix bound to the namespace URI is matched.
 ```go
 rep := mpd.NewRepresentation()
 rep.Codecs = "hvc1.2.4.L120.b0"
-rep.SupplementalCodecs = "dvh1.08.03"
-rep.SupplementalProfiles = "db1p"
+rep.SCTE214SupplementalCodecs = "dvh1.08.03"
+rep.SCTE214SupplementalProfiles = "db1p"
 
 asset := mpd.NewDescriptor(mpd.SCTE214SchemeIdAssetIdUpid, "", "")
-asset.ContentIdentifiers = []*mpd.ContentIdentifierType{
-    mpd.NewContentIdentifier("EIDR", "10.5240/EA73-79D7-1B2B-B378-3A73-M"),
+asset.SCTE214ContentIdentifiers = []*mpd.SCTE214ContentIdentifierType{
+    mpd.NewSCTE214ContentIdentifier("EIDR", "10.5240/EA73-79D7-1B2B-B378-3A73-M"),
 }
 period.AssetIdentifier = asset
 ```

--- a/mpd/mpd.go
+++ b/mpd/mpd.go
@@ -487,23 +487,27 @@ func (s *SubRepresentationType) Parent() *RepresentationType {
 
 // RepresentationBaseType is Representation base (common attributes and elements).
 type RepresentationBaseType struct {
-	Profiles                   ListOfProfilesType               `xml:"profiles,attr,omitempty"`
-	Width                      uint32                           `xml:"width,attr,omitempty"`
-	Height                     uint32                           `xml:"height,attr,omitempty"`
-	Sar                        RatioType                        `xml:"sar,attr,omitempty"`
-	FrameRate                  FrameRateType                    `xml:"frameRate,attr,omitempty"`
-	AudioSamplingRate          *UIntVectorType                  `xml:"audioSamplingRate,attr,omitempty"`
-	MimeType                   string                           `xml:"mimeType,attr,omitempty"`
-	SegmentProfiles            *ListOf4CCType                   `xml:"segmentProfiles,attr,omitempty"`
-	Codecs                     string                           `xml:"codecs,attr,omitempty"`
-	ContainerProfiles          *ListOf4CCType                   `xml:"containerProfiles,attr,omitempty"`
-	MaximumSAPPeriod           float64                          `xml:"maximumSAPPeriod,attr,omitempty"`
-	StartWithSAP               uint32                           `xml:"startWithSAP,attr,omitempty"`
-	MaxPlayoutRate             float64                          `xml:"maxPlayoutRate,attr,omitempty"`
-	CodingDependency           *bool                            `xml:"codingDependency,attr,omitempty"`
-	ScanType                   VideoScanType                    `xml:"scanType,attr,omitempty"`
-	SelectionPriority          *uint32                          `xml:"selectionPriority,attr"` // default = 1
-	Tag                        string                           `xml:"tag,attr,omitempty"`
+	Profiles          ListOfProfilesType `xml:"profiles,attr,omitempty"`
+	Width             uint32             `xml:"width,attr,omitempty"`
+	Height            uint32             `xml:"height,attr,omitempty"`
+	Sar               RatioType          `xml:"sar,attr,omitempty"`
+	FrameRate         FrameRateType      `xml:"frameRate,attr,omitempty"`
+	AudioSamplingRate *UIntVectorType    `xml:"audioSamplingRate,attr,omitempty"`
+	MimeType          string             `xml:"mimeType,attr,omitempty"`
+	SegmentProfiles   *ListOf4CCType     `xml:"segmentProfiles,attr,omitempty"`
+	Codecs            string             `xml:"codecs,attr,omitempty"`
+	ContainerProfiles *ListOf4CCType     `xml:"containerProfiles,attr,omitempty"`
+	MaximumSAPPeriod  float64            `xml:"maximumSAPPeriod,attr,omitempty"`
+	StartWithSAP      uint32             `xml:"startWithSAP,attr,omitempty"`
+	MaxPlayoutRate    float64            `xml:"maxPlayoutRate,attr,omitempty"`
+	CodingDependency  *bool              `xml:"codingDependency,attr,omitempty"`
+	ScanType          VideoScanType      `xml:"scanType,attr,omitempty"`
+	SelectionPriority *uint32            `xml:"selectionPriority,attr"` // default = 1
+	Tag               string             `xml:"tag,attr,omitempty"`
+	// SupplementalProfiles is a whitespace-separated list of SCTE 214-1 supplemental brands or URIs.
+	SupplementalProfiles StringVectorType `xml:"urn:scte:dash:scte214-extensions scte214:supplementalProfiles,attr,omitempty"`
+	// SupplementalCodecs is a whitespace-separated list of SCTE 214-1 supplemental RFC 6381 codec strings.
+	SupplementalCodecs         StringVectorType                 `xml:"urn:scte:dash:scte214-extensions scte214:supplementalCodecs,attr,omitempty"`
 	FramePackings              []*DescriptorType                `xml:"FramePacking"`
 	AudioChannelConfigurations []*DescriptorType                `xml:"AudioChannelConfiguration"`
 	ContentProtections         []*ContentProtectionType         `xml:"ContentProtection"`
@@ -921,6 +925,8 @@ type DescriptorType struct {
 	Id              string               `xml:"id,attr,omitempty"`
 	UrlQueryInfo    *UrlQueryInfoType    `xml:"urn:mpeg:dash:schema:urlparam:2014 up:UrlQueryInfo,omitempty"`
 	ExtUrlQueryInfo *ExtendedUrlInfoType `xml:"urn:mpeg:dash:schema:urlparam:2016 up:ExtUrlQueryInfo,omitempty"`
+	// ContentIdentifiers are SCTE 214-1 UPID content identifiers for asset identification.
+	ContentIdentifiers []*ContentIdentifierType `xml:"urn:scte:dash:scte214-extensions scte214:ContentIdentifier"`
 }
 
 // NewDescriptor returns a new DescriptorType.

--- a/mpd/mpd.go
+++ b/mpd/mpd.go
@@ -504,10 +504,10 @@ type RepresentationBaseType struct {
 	ScanType          VideoScanType      `xml:"scanType,attr,omitempty"`
 	SelectionPriority *uint32            `xml:"selectionPriority,attr"` // default = 1
 	Tag               string             `xml:"tag,attr,omitempty"`
-	// SupplementalProfiles is a whitespace-separated list of SCTE 214-1 supplemental brands or URIs.
-	SupplementalProfiles StringVectorType `xml:"urn:scte:dash:scte214-extensions scte214:supplementalProfiles,attr,omitempty"`
-	// SupplementalCodecs is a whitespace-separated list of SCTE 214-1 supplemental RFC 6381 codec strings.
-	SupplementalCodecs         StringVectorType                 `xml:"urn:scte:dash:scte214-extensions scte214:supplementalCodecs,attr,omitempty"`
+	// SCTE214SupplementalProfiles is a whitespace-separated list of SCTE 214-1 supplemental brands or URIs.
+	SCTE214SupplementalProfiles StringVectorType `xml:"urn:scte:dash:scte214-extensions scte214:supplementalProfiles,attr,omitempty"`
+	// SCTE214SupplementalCodecs is a whitespace-separated list of SCTE 214-1 supplemental RFC 6381 codec strings.
+	SCTE214SupplementalCodecs  StringVectorType                 `xml:"urn:scte:dash:scte214-extensions scte214:supplementalCodecs,attr,omitempty"`
 	FramePackings              []*DescriptorType                `xml:"FramePacking"`
 	AudioChannelConfigurations []*DescriptorType                `xml:"AudioChannelConfiguration"`
 	ContentProtections         []*ContentProtectionType         `xml:"ContentProtection"`
@@ -925,8 +925,8 @@ type DescriptorType struct {
 	Id              string               `xml:"id,attr,omitempty"`
 	UrlQueryInfo    *UrlQueryInfoType    `xml:"urn:mpeg:dash:schema:urlparam:2014 up:UrlQueryInfo,omitempty"`
 	ExtUrlQueryInfo *ExtendedUrlInfoType `xml:"urn:mpeg:dash:schema:urlparam:2016 up:ExtUrlQueryInfo,omitempty"`
-	// ContentIdentifiers are SCTE 214-1 UPID content identifiers for asset identification.
-	ContentIdentifiers []*ContentIdentifierType `xml:"urn:scte:dash:scte214-extensions scte214:ContentIdentifier"`
+	// SCTE214ContentIdentifiers are SCTE 214-1 UPID content identifiers for asset identification.
+	SCTE214ContentIdentifiers []*SCTE214ContentIdentifierType `xml:"urn:scte:dash:scte214-extensions scte214:ContentIdentifier"`
 }
 
 // NewDescriptor returns a new DescriptorType.

--- a/mpd/mpd_test.go
+++ b/mpd/mpd_test.go
@@ -29,6 +29,7 @@ func TestDecodeEncodeMPDs(t *testing.T) {
 		"testdata/hbbtv",
 		"testdata/other",
 		"testdata/scte35",
+		"testdata/scte214",
 	}
 	for _, testDir := range testDirs {
 		fsys := os.DirFS(testDir)

--- a/mpd/scte214.go
+++ b/mpd/scte214.go
@@ -1,0 +1,103 @@
+package mpd
+
+import (
+	"github.com/Eyevinn/dash-mpd/xml"
+)
+
+// SCTE-214 (ANSI/SCTE 214-1 2024) MPD extensions for DASH.
+//
+// This file maps the MPD extensions defined by SCTE 214-1 (MPEG DASH for
+// IP-Based Cable Services Part 1: MPD Constraints and Extensions) onto Go
+// types and constants:
+//
+//   - the supplementalProfiles and supplementalCodecs attributes extending
+//     RepresentationBaseType (Sec. 11.1.6, Table 8); the fields live on
+//     RepresentationBaseType in mpd.go and are therefore available on
+//     AdaptationSet, Representation and SubRepresentation
+//   - the ContentIdentifier element for UPID-based asset identification
+//     (Sec. 9.2); the field lives on DescriptorType in mpd.go and is
+//     therefore available on AssetIdentifier and SupplementalProperty
+//   - the descriptor schemeIdUri values defined throughout the document
+//     and listed in Annex A
+//
+// All extension elements and attributes belong to the SCTE214Namespace
+// ("urn:scte:dash:scte214-extensions"). The scte214 prefix is used on
+// marshal; on unmarshal any prefix bound to the namespace URI is matched.
+
+// SCTE-214 XML namespace URIs (ANSI/SCTE 214-1 2024 Annex A).
+const (
+	// SCTE214Namespace is the XML namespace for SCTE-214 MPD extensions,
+	// used by all editions of the specification after 2021.
+	SCTE214Namespace = "urn:scte:dash:scte214-extensions"
+	// SCTE214Namespace2021 is the XML namespace of the 2021 and prior
+	// editions of the specification.
+	SCTE214Namespace2021 = "urn:scte:dash:2021"
+)
+
+// Descriptor schemeIdUri values defined by ANSI/SCTE 214-1 2024.
+const (
+	// SCTE214SchemeIdAssetIdUpid identifies assets with SCTE-35 UPIDs.
+	// AssetIdentifier and SupplementalProperty descriptors with this
+	// scheme carry one or more ContentIdentifier elements (Sec. 9.2).
+	SCTE214SchemeIdAssetIdUpid = "urn:scte:dash:asset-id:upid:2015"
+	// SCTE214SchemeIdCEA608 signals CEA-608 closed caption services in
+	// Accessibility descriptors (Sec. 8.2.3).
+	SCTE214SchemeIdCEA608 = "urn:scte:dash:cc:cea-608:2015"
+	// SCTE214SchemeIdCEA708 signals CEA-708 closed caption services in
+	// Accessibility descriptors (Sec. 8.2.2).
+	SCTE214SchemeIdCEA708 = "urn:scte:dash:cc:cea-708:2015"
+	// SCTE214SchemeIdAssociatedService carries roles for non-accessibility
+	// associated audio services in Role descriptors (Sec. 8.1).
+	SCTE214SchemeIdAssociatedService = "urn:scte:dash:associated-service:2015"
+	// SCTE214SchemeIdEssentialEvent marks an event scheme whose processing
+	// is essential for the presentation, in EssentialProperty descriptors
+	// (Annex A).
+	SCTE214SchemeIdEssentialEvent = "urn:scte:dash:essential-event:2015"
+	// SCTE214SchemeIdAssetEnd marks the last period of an asset, in Period
+	// SupplementalProperty descriptors (Sec. 12.2).
+	SCTE214SchemeIdAssetEnd = "urn:scte:dash:asset-end"
+	// SCTE214SchemeIdAssetTime maps PeriodStart to an NPT or SMPTE
+	// timestamp relative to the asset start (Sec. 12.2).
+	SCTE214SchemeIdAssetTime = "urn:scte:dash:asset-time"
+	// SCTE214SchemeIdUTCTime maps PeriodStart to the UTC capture time of
+	// the first sample of the period (Sec. 12.2).
+	SCTE214SchemeIdUTCTime = "urn:scte:dash:utc-time"
+	// SCTE214SchemeIdPoweredBy identifies the software that generated the
+	// MPD or the XLink response (Sec. 14.1).
+	SCTE214SchemeIdPoweredBy = "urn:scte:dash:powered-by:2016"
+	// SCTE214SchemeIdGenerationInfo carries the location and time of MPD
+	// or XLink remote entity generation (Sec. 14.1).
+	SCTE214SchemeIdGenerationInfo = "urn:scte:dash:generation-info:2016"
+	// SCTE214SchemeIdGenerationRequest carries the HTTP request target
+	// that produced the MPD or XLink response (Sec. 14.1).
+	SCTE214SchemeIdGenerationRequest = "urn:scte:dash:generation-request:2016"
+	// SCTE214SchemeIdDefaultLanguage signals the default media language in
+	// SupplementalProperty descriptors. An optional URI fragment (#video,
+	// #audio, #text or #commentary) narrows the content component type it
+	// applies to (Sec. 8.1.2).
+	SCTE214SchemeIdDefaultLanguage = "urn:scte:dash:default-language"
+	// SCTE214SchemeIdIFrameTrack marks I-Frame track representations for
+	// trick modes (Sec. 11.3.3).
+	SCTE214SchemeIdIFrameTrack = "urn:scte:dash:i-frame-track:2021"
+	// SCTE214SchemeIdSegmentModel signals conformance to the SCTE segment
+	// model in SupplementalProperty descriptors (Sec. 10.1.1).
+	SCTE214SchemeIdSegmentModel = "urn:scte:dash:segment-model:2024"
+)
+
+// ContentIdentifierType is the scte214:ContentIdentifier element (XSD
+// complexType UPID) defined in Sec. 9.2 of ANSI/SCTE 214-1 2024. Type is an
+// SCTE-35 UPID type name and Value its textual representation, both as
+// specified by table 9-7 of ANSI/SCTE 35. One or more ContentIdentifier
+// elements appear inside an AssetIdentifier or SupplementalProperty
+// descriptor with schemeIdUri SCTE214SchemeIdAssetIdUpid.
+type ContentIdentifierType struct {
+	Type     string     `xml:"type,attr"`
+	Value    string     `xml:"value,attr"`
+	AnyAttrs []xml.Attr `xml:",any,attr"`
+}
+
+// NewContentIdentifier returns a ContentIdentifier with the given SCTE-35
+// UPID type name and value.
+func NewContentIdentifier(idType, idValue string) *ContentIdentifierType {
+	return &ContentIdentifierType{Type: idType, Value: idValue}
+}

--- a/mpd/scte214.go
+++ b/mpd/scte214.go
@@ -84,20 +84,20 @@ const (
 	SCTE214SchemeIdSegmentModel = "urn:scte:dash:segment-model:2024"
 )
 
-// ContentIdentifierType is the scte214:ContentIdentifier element (XSD
+// SCTE214ContentIdentifierType is the scte214:ContentIdentifier element (XSD
 // complexType UPID) defined in Sec. 9.2 of ANSI/SCTE 214-1 2024. Type is an
 // SCTE-35 UPID type name and Value its textual representation, both as
 // specified by table 9-7 of ANSI/SCTE 35. One or more ContentIdentifier
 // elements appear inside an AssetIdentifier or SupplementalProperty
 // descriptor with schemeIdUri SCTE214SchemeIdAssetIdUpid.
-type ContentIdentifierType struct {
+type SCTE214ContentIdentifierType struct {
 	Type     string     `xml:"type,attr"`
 	Value    string     `xml:"value,attr"`
 	AnyAttrs []xml.Attr `xml:",any,attr"`
 }
 
-// NewContentIdentifier returns a ContentIdentifier with the given SCTE-35
-// UPID type name and value.
-func NewContentIdentifier(idType, idValue string) *ContentIdentifierType {
-	return &ContentIdentifierType{Type: idType, Value: idValue}
+// NewSCTE214ContentIdentifier returns a ContentIdentifier with the given
+// SCTE-35 UPID type name and value.
+func NewSCTE214ContentIdentifier(idType, idValue string) *SCTE214ContentIdentifierType {
+	return &SCTE214ContentIdentifierType{Type: idType, Value: idValue}
 }

--- a/mpd/scte214_test.go
+++ b/mpd/scte214_test.go
@@ -37,8 +37,8 @@ func TestSCTE214SupplementalAttributes(t *testing.T) {
 			reps := m.Periods[0].AdaptationSets[0].Representations
 			require.Len(t, reps, len(tc.wantCodecs))
 			for i, rep := range reps {
-				require.Equal(t, tc.wantProfiles[i], rep.SupplementalProfiles)
-				require.Equal(t, tc.wantCodecs[i], rep.SupplementalCodecs)
+				require.Equal(t, tc.wantProfiles[i], rep.SCTE214SupplementalProfiles)
+				require.Equal(t, tc.wantCodecs[i], rep.SCTE214SupplementalCodecs)
 			}
 		})
 	}
@@ -53,8 +53,8 @@ func TestSCTE214SupplementalAttributesOnAdaptationSet(t *testing.T) {
 	require.NoError(t, err)
 
 	as := m.Periods[0].AdaptationSets[0]
-	require.Equal(t, mpd.StringVectorType("db1p cdm4"), as.SupplementalProfiles)
-	require.Equal(t, mpd.StringVectorType("dvh1.08.09"), as.SupplementalCodecs)
+	require.Equal(t, mpd.StringVectorType("db1p cdm4"), as.SCTE214SupplementalProfiles)
+	require.Equal(t, mpd.StringVectorType("dvh1.08.09"), as.SCTE214SupplementalCodecs)
 }
 
 // TestSCTE214NamespacePrefixInsensitive verifies that the attributes are
@@ -72,8 +72,8 @@ func TestSCTE214NamespacePrefixInsensitive(t *testing.T) {
 	m, err := mpd.MPDFromBytes([]byte(input))
 	require.NoError(t, err)
 	rep := m.Periods[0].AdaptationSets[0].Representations[0]
-	require.Equal(t, mpd.StringVectorType("db1p"), rep.SupplementalProfiles)
-	require.Equal(t, mpd.StringVectorType("dvh1.08.05"), rep.SupplementalCodecs)
+	require.Equal(t, mpd.StringVectorType("db1p"), rep.SCTE214SupplementalProfiles)
+	require.Equal(t, mpd.StringVectorType("dvh1.08.05"), rep.SCTE214SupplementalCodecs)
 
 	// On marshal, the attributes come out with the scte214 prefix declared
 	// on the carrying element.
@@ -98,18 +98,18 @@ func TestSCTE214ContentIdentifiers(t *testing.T) {
 	ai := p.AssetIdentifier
 	require.NotNil(t, ai)
 	require.Equal(t, mpd.AnyURI(mpd.SCTE214SchemeIdAssetIdUpid), ai.SchemeIdUri)
-	require.Len(t, ai.ContentIdentifiers, 2)
-	require.Equal(t, "ADI", ai.ContentIdentifiers[0].Type)
-	require.Equal(t, "cablelabs.com/MOVE1234567890123456", ai.ContentIdentifiers[0].Value)
-	require.Equal(t, "MPU", ai.ContentIdentifiers[1].Type)
-	require.Equal(t, "CSP1DE12AB327FE312AF", ai.ContentIdentifiers[1].Value)
+	require.Len(t, ai.SCTE214ContentIdentifiers, 2)
+	require.Equal(t, "ADI", ai.SCTE214ContentIdentifiers[0].Type)
+	require.Equal(t, "cablelabs.com/MOVE1234567890123456", ai.SCTE214ContentIdentifiers[0].Value)
+	require.Equal(t, "MPU", ai.SCTE214ContentIdentifiers[1].Type)
+	require.Equal(t, "CSP1DE12AB327FE312AF", ai.SCTE214ContentIdentifiers[1].Value)
 
 	require.Len(t, p.SupplementalProperties, 1)
 	sp := p.SupplementalProperties[0]
 	require.Equal(t, mpd.AnyURI(mpd.SCTE214SchemeIdAssetIdUpid), sp.SchemeIdUri)
-	require.Len(t, sp.ContentIdentifiers, 1)
-	require.Equal(t, "AiringID", sp.ContentIdentifiers[0].Type)
-	require.Equal(t, "0xDEADBEEF", sp.ContentIdentifiers[0].Value)
+	require.Len(t, sp.SCTE214ContentIdentifiers, 1)
+	require.Equal(t, "AiringID", sp.SCTE214ContentIdentifiers[0].Type)
+	require.Equal(t, "0xDEADBEEF", sp.SCTE214ContentIdentifiers[0].Value)
 }
 
 // TestSCTE214ProgrammaticConstruction builds the SCTE-214 signalling
@@ -125,8 +125,8 @@ func TestSCTE214ProgrammaticConstruction(t *testing.T) {
 	m.AppendPeriod(p)
 
 	ai := mpd.NewDescriptor(mpd.SCTE214SchemeIdAssetIdUpid, "", "")
-	ai.ContentIdentifiers = []*mpd.ContentIdentifierType{
-		mpd.NewContentIdentifier("EIDR", "10.5240/EA73-79D7-1B2B-B378-3A73-M"),
+	ai.SCTE214ContentIdentifiers = []*mpd.SCTE214ContentIdentifierType{
+		mpd.NewSCTE214ContentIdentifier("EIDR", "10.5240/EA73-79D7-1B2B-B378-3A73-M"),
 	}
 	p.AssetIdentifier = ai
 
@@ -138,8 +138,8 @@ func TestSCTE214ProgrammaticConstruction(t *testing.T) {
 	rep.Id = "video"
 	rep.Bandwidth = 5139658
 	rep.Codecs = "hvc1.2.4.L120.b0"
-	rep.SupplementalProfiles = "db1p cdm4"
-	rep.SupplementalCodecs = "dvh1.08.03"
+	rep.SCTE214SupplementalProfiles = "db1p cdm4"
+	rep.SCTE214SupplementalCodecs = "dvh1.08.03"
 	as.AppendRepresentation(rep)
 
 	out, err := xml.MarshalIndent(m, "", "  ")
@@ -154,10 +154,10 @@ func TestSCTE214ProgrammaticConstruction(t *testing.T) {
 	rt, err := mpd.MPDFromBytes(out)
 	require.NoError(t, err)
 	rtRep := rt.Periods[0].AdaptationSets[0].Representations[0]
-	require.Equal(t, mpd.StringVectorType("db1p cdm4"), rtRep.SupplementalProfiles)
-	require.Equal(t, mpd.StringVectorType("dvh1.08.03"), rtRep.SupplementalCodecs)
+	require.Equal(t, mpd.StringVectorType("db1p cdm4"), rtRep.SCTE214SupplementalProfiles)
+	require.Equal(t, mpd.StringVectorType("dvh1.08.03"), rtRep.SCTE214SupplementalCodecs)
 	rtAi := rt.Periods[0].AssetIdentifier
 	require.NotNil(t, rtAi)
-	require.Len(t, rtAi.ContentIdentifiers, 1)
-	require.Equal(t, "EIDR", rtAi.ContentIdentifiers[0].Type)
+	require.Len(t, rtAi.SCTE214ContentIdentifiers, 1)
+	require.Equal(t, "EIDR", rtAi.SCTE214ContentIdentifiers[0].Type)
 }

--- a/mpd/scte214_test.go
+++ b/mpd/scte214_test.go
@@ -1,0 +1,163 @@
+package mpd_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/Eyevinn/dash-mpd/mpd"
+	"github.com/Eyevinn/dash-mpd/xml"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSCTE214SupplementalAttributes verifies that the SCTE-214
+// supplementalProfiles and supplementalCodecs attributes are read on both
+// AdaptationSet and Representation, whatever prefix the input binds to the
+// SCTE-214 namespace URI.
+func TestSCTE214SupplementalAttributes(t *testing.T) {
+	cases := []struct {
+		desc         string
+		file         string
+		wantProfiles []mpd.StringVectorType
+		wantCodecs   []mpd.StringVectorType
+	}{
+		{
+			desc:         "Representation level, one value per attribute",
+			file:         "testdata/scte214/supplemental_codecs_representation.mpd",
+			wantProfiles: []mpd.StringVectorType{"db1p", "db1p"},
+			wantCodecs:   []mpd.StringVectorType{"dvh1.08.01", "dvh1.08.03"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.desc, func(t *testing.T) {
+			data, err := os.ReadFile(tc.file)
+			require.NoError(t, err)
+			m, err := mpd.MPDFromBytes(data)
+			require.NoError(t, err)
+
+			reps := m.Periods[0].AdaptationSets[0].Representations
+			require.Len(t, reps, len(tc.wantCodecs))
+			for i, rep := range reps {
+				require.Equal(t, tc.wantProfiles[i], rep.SupplementalProfiles)
+				require.Equal(t, tc.wantCodecs[i], rep.SupplementalCodecs)
+			}
+		})
+	}
+}
+
+// TestSCTE214SupplementalAttributesOnAdaptationSet covers the AdaptationSet
+// placement and space-separated multi-value lists.
+func TestSCTE214SupplementalAttributesOnAdaptationSet(t *testing.T) {
+	data, err := os.ReadFile("testdata/scte214/supplemental_codecs_adaptation_set.mpd")
+	require.NoError(t, err)
+	m, err := mpd.MPDFromBytes(data)
+	require.NoError(t, err)
+
+	as := m.Periods[0].AdaptationSets[0]
+	require.Equal(t, mpd.StringVectorType("db1p cdm4"), as.SupplementalProfiles)
+	require.Equal(t, mpd.StringVectorType("dvh1.08.09"), as.SupplementalCodecs)
+}
+
+// TestSCTE214NamespacePrefixInsensitive verifies that the attributes are
+// matched by namespace URI, not by prefix, so manifests binding any prefix
+// to the SCTE-214 namespace are read correctly.
+func TestSCTE214NamespacePrefixInsensitive(t *testing.T) {
+	input := `<MPD xmlns="urn:mpeg:dash:schema:mpd:2011" xmlns:_="urn:scte:dash:scte214-extensions"` +
+		` profiles="urn:mpeg:dash:profile:isoff-on-demand:2011" type="static"` +
+		` mediaPresentationDuration="PT30S" minBufferTime="PT2S">` +
+		`<Period id="1"><AdaptationSet id="1" mimeType="video/mp4">` +
+		`<Representation id="v0" bandwidth="4725303" codecs="hvc1.2.4.L150.90"` +
+		` _:supplementalProfiles="db1p" _:supplementalCodecs="dvh1.08.05"></Representation>` +
+		`</AdaptationSet></Period></MPD>`
+
+	m, err := mpd.MPDFromBytes([]byte(input))
+	require.NoError(t, err)
+	rep := m.Periods[0].AdaptationSets[0].Representations[0]
+	require.Equal(t, mpd.StringVectorType("db1p"), rep.SupplementalProfiles)
+	require.Equal(t, mpd.StringVectorType("dvh1.08.05"), rep.SupplementalCodecs)
+
+	// On marshal, the attributes come out with the scte214 prefix declared
+	// on the carrying element.
+	out, err := xml.MarshalIndent(m, "", "  ")
+	require.NoError(t, err)
+	s := string(out)
+	require.Contains(t, s, `xmlns:scte214="urn:scte:dash:scte214-extensions"`)
+	require.Contains(t, s, `scte214:supplementalProfiles="db1p"`)
+	require.Contains(t, s, `scte214:supplementalCodecs="dvh1.08.05"`)
+}
+
+// TestSCTE214ContentIdentifiers covers ContentIdentifier elements inside
+// AssetIdentifier and SupplementalProperty descriptors with the
+// urn:scte:dash:asset-id:upid:2015 scheme.
+func TestSCTE214ContentIdentifiers(t *testing.T) {
+	data, err := os.ReadFile("testdata/scte214/asset_id_upid.mpd")
+	require.NoError(t, err)
+	m, err := mpd.MPDFromBytes(data)
+	require.NoError(t, err)
+
+	p := m.Periods[0]
+	ai := p.AssetIdentifier
+	require.NotNil(t, ai)
+	require.Equal(t, mpd.AnyURI(mpd.SCTE214SchemeIdAssetIdUpid), ai.SchemeIdUri)
+	require.Len(t, ai.ContentIdentifiers, 2)
+	require.Equal(t, "ADI", ai.ContentIdentifiers[0].Type)
+	require.Equal(t, "cablelabs.com/MOVE1234567890123456", ai.ContentIdentifiers[0].Value)
+	require.Equal(t, "MPU", ai.ContentIdentifiers[1].Type)
+	require.Equal(t, "CSP1DE12AB327FE312AF", ai.ContentIdentifiers[1].Value)
+
+	require.Len(t, p.SupplementalProperties, 1)
+	sp := p.SupplementalProperties[0]
+	require.Equal(t, mpd.AnyURI(mpd.SCTE214SchemeIdAssetIdUpid), sp.SchemeIdUri)
+	require.Len(t, sp.ContentIdentifiers, 1)
+	require.Equal(t, "AiringID", sp.ContentIdentifiers[0].Type)
+	require.Equal(t, "0xDEADBEEF", sp.ContentIdentifiers[0].Value)
+}
+
+// TestSCTE214ProgrammaticConstruction builds the SCTE-214 signalling
+// programmatically, marshals it and checks the output, then parses it back.
+func TestSCTE214ProgrammaticConstruction(t *testing.T) {
+	m := mpd.NewMPD(mpd.STATIC_TYPE)
+	m.Profiles = mpd.PROFILE_ONDEMAND
+	m.MediaPresentationDuration = mpd.Seconds2DurPtr(30)
+	m.MinBufferTime = mpd.Seconds2DurPtr(2)
+
+	p := mpd.NewPeriod()
+	p.Id = "1"
+	m.AppendPeriod(p)
+
+	ai := mpd.NewDescriptor(mpd.SCTE214SchemeIdAssetIdUpid, "", "")
+	ai.ContentIdentifiers = []*mpd.ContentIdentifierType{
+		mpd.NewContentIdentifier("EIDR", "10.5240/EA73-79D7-1B2B-B378-3A73-M"),
+	}
+	p.AssetIdentifier = ai
+
+	as := mpd.NewAdaptationSet()
+	as.MimeType = "video/mp4"
+	p.AppendAdaptationSet(as)
+
+	rep := mpd.NewRepresentation()
+	rep.Id = "video"
+	rep.Bandwidth = 5139658
+	rep.Codecs = "hvc1.2.4.L120.b0"
+	rep.SupplementalProfiles = "db1p cdm4"
+	rep.SupplementalCodecs = "dvh1.08.03"
+	as.AppendRepresentation(rep)
+
+	out, err := xml.MarshalIndent(m, "", "  ")
+	require.NoError(t, err)
+	s := string(out)
+	require.Contains(t, s, `xmlns:scte214="urn:scte:dash:scte214-extensions"`)
+	require.Contains(t, s, `scte214:supplementalProfiles="db1p cdm4"`)
+	require.Contains(t, s, `scte214:supplementalCodecs="dvh1.08.03"`)
+	require.Contains(t, s, `<scte214:ContentIdentifier`)
+	require.Contains(t, s, `type="EIDR" value="10.5240/EA73-79D7-1B2B-B378-3A73-M"`)
+
+	rt, err := mpd.MPDFromBytes(out)
+	require.NoError(t, err)
+	rtRep := rt.Periods[0].AdaptationSets[0].Representations[0]
+	require.Equal(t, mpd.StringVectorType("db1p cdm4"), rtRep.SupplementalProfiles)
+	require.Equal(t, mpd.StringVectorType("dvh1.08.03"), rtRep.SupplementalCodecs)
+	rtAi := rt.Periods[0].AssetIdentifier
+	require.NotNil(t, rtAi)
+	require.Len(t, rtAi.ContentIdentifiers, 1)
+	require.Equal(t, "EIDR", rtAi.ContentIdentifiers[0].Type)
+}

--- a/mpd/testdata/scte214/README.md
+++ b/mpd/testdata/scte214/README.md
@@ -1,0 +1,29 @@
+# SCTE-214 test fixtures
+
+DASH MPDs carrying SCTE-214 MPD extensions, used by
+`TestDecodeEncodeMPDs` to validate the unmarshal/marshal round-trip
+of the types and attributes in `mpd/scte214.go`.
+
+The extensions are defined by [ANSI/SCTE 214-1 2024][214-1] (MPEG DASH
+for IP-Based Cable Services Part 1: MPD Constraints and Extensions):
+the `supplementalProfiles` and `supplementalCodecs` attributes on
+RepresentationBaseType (Sec. 11.1.6, Table 8) and the
+`ContentIdentifier` element for UPID-based asset identification
+(Sec. 9.2). All of them belong to the
+`urn:scte:dash:scte214-extensions` namespace (Annex A).
+
+Each fixture is hand-written and verified to round-trip unchanged
+through the package. DASH attributes use the order produced by the
+marshaller and the `xmlns:scte214` declaration sits on the carrying
+element, both existing constraints of the round-trip test.
+Attribute values follow those seen in production manifests
+(Dolby Vision 8.1 over HEVC, HDR10+) and the signaling examples of
+Sec. 11.1.7.
+
+| File | What it covers |
+|---|---|
+| `supplemental_codecs_representation.mpd` | `supplementalCodecs`/`supplementalProfiles` on `Representation`, with different codec strings per representation (Dolby Vision 8.1 over HEVC) |
+| `supplemental_codecs_adaptation_set.mpd` | the attributes on `AdaptationSet` with a space-separated multi-value `supplementalProfiles` list (`db1p cdm4`, Dolby Vision 8.1 + HDR10+) |
+| `asset_id_upid.mpd` | `ContentIdentifier` elements inside `AssetIdentifier` and `SupplementalProperty` descriptors with the `urn:scte:dash:asset-id:upid:2015` scheme |
+
+[214-1]: https://account.scte.org/standards/library/catalog/scte-214-1-mpeg-dash-for-ip-based-cable-services-part1-mpd-constraints-and-extensions/

--- a/mpd/testdata/scte214/asset_id_upid.mpd
+++ b/mpd/testdata/scte214/asset_id_upid.mpd
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<MPD xmlns="urn:mpeg:dash:schema:mpd:2011" profiles="urn:mpeg:dash:profile:isoff-live:2011" type="static" mediaPresentationDuration="PT2M" minBufferTime="PT2S">
+  <Period id="1">
+    <AssetIdentifier schemeIdUri="urn:scte:dash:asset-id:upid:2015">
+      <scte214:ContentIdentifier xmlns:scte214="urn:scte:dash:scte214-extensions" type="ADI" value="cablelabs.com/MOVE1234567890123456"></scte214:ContentIdentifier>
+      <scte214:ContentIdentifier xmlns:scte214="urn:scte:dash:scte214-extensions" type="MPU" value="CSP1DE12AB327FE312AF"></scte214:ContentIdentifier>
+    </AssetIdentifier>
+    <AdaptationSet id="1" segmentAlignment="true" mimeType="video/mp4" startWithSAP="1">
+      <SegmentTemplate media="content_$Number$.mp4" initialization="content_init.mp4" timescale="90000" duration="180000"></SegmentTemplate>
+      <Representation id="video" bandwidth="3000000" width="1280" height="720" codecs="avc1.4D401F"></Representation>
+    </AdaptationSet>
+    <SupplementalProperty schemeIdUri="urn:scte:dash:asset-id:upid:2015">
+      <scte214:ContentIdentifier xmlns:scte214="urn:scte:dash:scte214-extensions" type="AiringID" value="0xDEADBEEF"></scte214:ContentIdentifier>
+    </SupplementalProperty>
+  </Period>
+</MPD>

--- a/mpd/testdata/scte214/supplemental_codecs_adaptation_set.mpd
+++ b/mpd/testdata/scte214/supplemental_codecs_adaptation_set.mpd
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<MPD xmlns="urn:mpeg:dash:schema:mpd:2011" profiles="urn:mpeg:dash:profile:isoff-on-demand:2011" type="static" mediaPresentationDuration="PT30S" minBufferTime="PT2S">
+  <Period id="1">
+    <AdaptationSet id="1" segmentAlignment="true" mimeType="video/mp4" codecs="hev1.2.4.L153.B0" containerProfiles="cmfc chd1" startWithSAP="1" xmlns:scte214="urn:scte:dash:scte214-extensions" scte214:supplementalProfiles="db1p cdm4" scte214:supplementalCodecs="dvh1.08.09">
+      <EssentialProperty schemeIdUri="urn:mpeg:mpegB:cicp:MatrixCoefficients" value="9"></EssentialProperty>
+      <EssentialProperty schemeIdUri="urn:mpeg:mpegB:cicp:ColourPrimaries" value="9"></EssentialProperty>
+      <EssentialProperty schemeIdUri="urn:mpeg:mpegB:cicp:TransferCharacteristics" value="16"></EssentialProperty>
+      <SegmentTemplate media="video_$Number$.mp4" initialization="video_init.mp4" timescale="90000" duration="180000"></SegmentTemplate>
+      <Representation id="video-2160p" bandwidth="12000000" width="3840" height="2160"></Representation>
+    </AdaptationSet>
+  </Period>
+</MPD>

--- a/mpd/testdata/scte214/supplemental_codecs_representation.mpd
+++ b/mpd/testdata/scte214/supplemental_codecs_representation.mpd
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<MPD xmlns="urn:mpeg:dash:schema:mpd:2011" profiles="urn:mpeg:dash:profile:isoff-on-demand:2011" type="static" mediaPresentationDuration="PT1M11.708S" minBufferTime="PT2S">
+  <Period id="1">
+    <AdaptationSet id="1" maxWidth="1920" maxHeight="1080" segmentAlignment="true" subsegmentAlignment="true" subsegmentStartsWithSAP="1" mimeType="video/mp4" startWithSAP="1">
+      <EssentialProperty schemeIdUri="urn:mpeg:mpegB:cicp:TransferCharacteristics" value="16"></EssentialProperty>
+      <Representation id="video-720p" bandwidth="1630943" width="1280" height="720" frameRate="24" codecs="hvc1.2.4.L93.b0" xmlns:scte214="urn:scte:dash:scte214-extensions" scte214:supplementalProfiles="db1p" scte214:supplementalCodecs="dvh1.08.01">
+        <BaseURL>video_720p.mp4</BaseURL>
+      </Representation>
+      <Representation id="video-1080p" bandwidth="5139658" width="1920" height="1080" frameRate="24" codecs="hvc1.2.4.L120.b0" xmlns:scte214="urn:scte:dash:scte214-extensions" scte214:supplementalProfiles="db1p" scte214:supplementalCodecs="dvh1.08.03">
+        <BaseURL>video_1080p.mp4</BaseURL>
+      </Representation>
+    </AdaptationSet>
+  </Period>
+</MPD>


### PR DESCRIPTION
## What
Add the MPD extensions defined by ANSI/SCTE 214-1 2024 (MPD Constraints and Extensions):
- `scte214:supplementalProfiles` / `scte214:supplementalCodecs` attributes on
  `RepresentationBaseType` (Sec. 11.1.6, Table 8), hence available on `AdaptationSet`,
  `Representation` and `SubRepresentation`. Both are whitespace-separated lists
  (`StringVectorType`).
- `scte214:ContentIdentifier` elements (complexType `UPID`, Sec. 9.2) on `DescriptorType`,
  for UPID-based asset identification in `AssetIdentifier` and `SupplementalProperty`
  descriptors with the `urn:scte:dash:asset-id:upid:2015` scheme.
- Exported constants: `SCTE214Namespace`, `SCTE214Namespace2021`, and the descriptor
  scheme URIs defined by the specification (`SCTE214SchemeId*`).
## Why
These attributes are silently dropped by the parser today. They are the standard DASH
signalling for backwards-compatible Dolby Vision and HDR10+ (emitted by Shaka Packager,
Bento4 and Dolby production streams, parsed by ExoPlayer, dash.js, Shaka Player).
## Notes
- All extensions live in the `urn:scte:dash:scte214-extensions` namespace (Annex A).
  The `scte214` prefix is emitted on marshal, declared on the carrying element; on
  unmarshal any prefix bound to the namespace URI is matched.
- Round-trip fixtures in `mpd/testdata/scte214/` follow production manifests
  (per-Representation Dolby Vision 8.1 codec strings, multi-value list on
  AdaptationSet) and the signaling examples of Sec. 11.1.7.